### PR TITLE
fix: null safety, validation UX, and unnecessary stats rebuilds v2.4.11-hotfix

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -120,30 +120,6 @@ class MyApp extends StatelessWidget {
                               null
                           ? const LandingPage()
                           : const HomePage();
-                  if (auth.isOffline) {
-                    return Stack(
-                      children: [
-                        content,
-                        Positioned(
-                          top: 0,
-                          left: 0,
-                          right: 0,
-                          child: MaterialBanner(
-                            backgroundColor: Colors.amber.shade100,
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 16, vertical: 8),
-                            leading: Icon(Icons.cloud_off,
-                                color: Colors.amber.shade800),
-                            content: Text(
-                              'أنت غير متصل بالإنترنت. يتم عرض البيانات المحفوظة.',
-                              style: const TextStyle(fontSize: 13),
-                            ),
-                            actions: const [SizedBox.shrink()],
-                          ),
-                        ),
-                      ],
-                    );
-                  }
                   return content;
                 }
                 return LoginPage();

--- a/lib/pages/InsertPage.dart
+++ b/lib/pages/InsertPage.dart
@@ -121,11 +121,16 @@ class _InPageState extends State<InPage> {
         icon: const Icon(Icons.error_outline_rounded),
         iconColor: Colors.red,
         title: const Text(
-          'أدخل قيم صحيحة',
+          'خطأ في الإدخال',
           style: TextStyle(
             fontSize: 20,
             fontWeight: FontWeight.bold,
           ),
+        ),
+        content: Text(
+          message,
+          textAlign: TextAlign.center,
+          style: const TextStyle(fontSize: 16),
         ),
       ),
     );
@@ -411,26 +416,52 @@ class _InPageState extends State<InPage> {
                     onPressed: () {
                       if (widget.index == -1) {
                         if (_validateFields()) {
+                          final buyPrice = double.tryParse(widget.buyCon.text);
+                          if (buyPrice == null) {
+                            _showErrorDialog(context, 'سعر الشراء يجب أن يكون رقماً');
+                            return;
+                          }
+                          final sellPrice = double.tryParse(widget.sellCon.text);
+                          if (sellPrice == null) {
+                            _showErrorDialog(context, 'سعر البيع يجب أن يكون رقماً');
+                            return;
+                          }
+                          final countText = widget.countCon.text;
+                          if (double.tryParse(countText) == null) {
+                            _showErrorDialog(context, 'الكمية يجب أن تكون رقماً');
+                            return;
+                          }
+                          if (widget.offer) {
+                            if (double.tryParse(widget.offerCountCon.text) == null) {
+                              _showErrorDialog(context, 'عدد العرض يجب أن يكون رقماً');
+                              return;
+                            }
+                            if (widget.offerPriceCon.text.isNotEmpty &&
+                                double.tryParse(widget.offerPriceCon.text) == null) {
+                              _showErrorDialog(context, 'سعر العرض يجب أن يكون رقماً');
+                              return;
+                            }
+                          }
                           List<Product> temp = [];
                           Product temp2 = Product.named(
                             name: widget.nameCon.text,
                             barcode: widget.BarcodeCon.text,
                             buyprice: widget.weightable
-                                ? double.parse(widget.buyCon.text) /
+                                ? buyPrice /
                                     getWholeUnitNumber(widget.wholeUnitCon.text)
                                         .toDouble()
-                                : double.parse(widget.buyCon.text),
+                                : buyPrice,
                             sellPrice: widget.weightable
-                                ? double.parse(widget.sellCon.text) /
+                                ? sellPrice /
                                     getWholeUnitNumber(widget.wholeUnitCon.text)
                                         .toDouble()
-                                : double.parse(widget.sellCon.text),
+                                : sellPrice,
                             count: widget.weightable
                                 ? unPadd(
-                                        padded: widget.countCon.text,
+                                        padded: countText,
                                         wholeUnit: widget.wholeUnitCon.text)
                                     .toInt()
-                                : (double.tryParse(widget.countCon.text) ?? 0)
+                                : (double.tryParse(countText) ?? 0)
                                     .toInt(),
                             ownerName: widget.ownerCon.text,
                             weightable: widget.weightable,
@@ -443,7 +474,6 @@ class _InPageState extends State<InPage> {
                                     ? '0'
                                     : widget.offerPriceCon.text,
                                 wholeUnit: widget.offerCountCon.text),
-                            // double.tryParse(widget.offerPriceCon.text) ?? 0,
                             priceHistory: widget.priceHistory,
                             endDate: widget.endDate,
                             hot: false,
@@ -456,13 +486,37 @@ class _InPageState extends State<InPage> {
                           }
                           Navigator.pop(context);
                           li.db.insertProducts(products: temp);
-                          // sa.refreshProductsList();
-                          // sa.refresh();
                         } else {
                           _showErrorDialog(context, 'ادخل قيم صحيحة');
                         }
                       } else {
                         if (_validateFields()) {
+                          final buyPrice = double.tryParse(widget.buyCon.text);
+                          if (buyPrice == null) {
+                            _showErrorDialog(context, 'سعر الشراء يجب أن يكون رقماً');
+                            return;
+                          }
+                          final sellPrice = double.tryParse(widget.sellCon.text);
+                          if (sellPrice == null) {
+                            _showErrorDialog(context, 'سعر البيع يجب أن يكون رقماً');
+                            return;
+                          }
+                          final countText = widget.countCon.text;
+                          if (double.tryParse(countText) == null) {
+                            _showErrorDialog(context, 'الكمية يجب أن تكون رقماً');
+                            return;
+                          }
+                          if (widget.offer) {
+                            if (double.tryParse(widget.offerCountCon.text) == null) {
+                              _showErrorDialog(context, 'عدد العرض يجب أن يكون رقماً');
+                              return;
+                            }
+                            if (widget.offerPriceCon.text.isNotEmpty &&
+                                double.tryParse(widget.offerPriceCon.text) == null) {
+                              _showErrorDialog(context, 'سعر العرض يجب أن يكون رقماً');
+                              return;
+                            }
+                          }
                           Emap emap = Emap()
                             ..buyPrice = widget.buyPrice
                             ..sellPrice = widget.sellPrice
@@ -473,21 +527,21 @@ class _InPageState extends State<InPage> {
                             name: widget.nameCon.text,
                             barcode: widget.BarcodeCon.text,
                             buyprice: widget.weightable
-                                ? double.parse(widget.buyCon.text) /
+                                ? buyPrice /
                                     getWholeUnitNumber(widget.wholeUnitCon.text)
                                         .toDouble()
-                                : double.parse(widget.buyCon.text),
+                                : buyPrice,
                             sellPrice: widget.weightable
-                                ? double.parse(widget.sellCon.text) /
+                                ? sellPrice /
                                     getWholeUnitNumber(widget.wholeUnitCon.text)
                                         .toDouble()
-                                : double.parse(widget.sellCon.text),
+                                : sellPrice,
                             count: widget.weightable
                                 ? unPadd(
-                                        padded: widget.countCon.text,
+                                        padded: countText,
                                         wholeUnit: widget.wholeUnitCon.text)
                                     .toInt()
-                                : (double.tryParse(widget.countCon.text) ?? 0)
+                                : (double.tryParse(countText) ?? 0)
                                     .toInt(),
                             ownerName: widget.ownerCon.text,
                             weightable: widget.weightable,
@@ -500,7 +554,6 @@ class _InPageState extends State<InPage> {
                                     ? '0'
                                     : widget.offerPriceCon.text,
                                 wholeUnit: widget.offerCountCon.text),
-                            // double.tryParse(widget.offerPriceCon.text) ?? 0,
                             priceHistory: widget.priceHistory,
                             endDate: widget.endDate,
                             hot: false,
@@ -511,8 +564,6 @@ class _InPageState extends State<InPage> {
                             return;
                           }
                           sa.updateProduct(temp2);
-                          // sa.refreshProductsList();
-                          // li.refresh();
                           Navigator.pop(context);
                         } else {
                           _showErrorDialog(context, 'ادخل قيم صحيحة');

--- a/lib/pages/StatsPage.dart
+++ b/lib/pages/StatsPage.dart
@@ -7,303 +7,335 @@ import 'package:provider/provider.dart';
 import '../providers/list.dart';
 import '../util/charts.dart';
 
-class StatsPage extends StatelessWidget {
+class StatsPage extends StatefulWidget {
   const StatsPage({super.key});
 
   @override
+  State<StatsPage> createState() => _StatsPageState();
+}
+
+class _StatsPageState extends State<StatsPage> {
+  int _lastCacheVersion = -1;
+  final ScrollController _scrollController = ScrollController();
+  bool _tabListenerAdded = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_tabListenerAdded) {
+      DefaultTabController.of(context).addListener(_onTabChanged);
+      _tabListenerAdded = true;
+    }
+  }
+
+  @override
+  void dispose() {
+    DefaultTabController.of(context).removeListener(_onTabChanged);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onTabChanged() {
+    if (DefaultTabController.of(context).index != 1) return;
+    final li = context.read<Lists>();
+    if (_lastCacheVersion == li.cacheVersion) return;
+    _lastCacheVersion = li.cacheVersion;
+    setState(() {});
+  }
+
+  @override
   Widget build(BuildContext context) {
-    // print('list');
-    final li = Provider.of<Lists>(context, listen: false);
-    final ScrollController sc = ScrollController();
+    final li = context.read<Lists>();
+    if (_lastCacheVersion == -1) _lastCacheVersion = li.cacheVersion;
     return Scaffold(
       body: Flex(
         direction: Axis.vertical,
         children: [
           Expanded(
             child: ListView(
-              controller: sc,
+              controller: _scrollController,
               physics: const ClampingScrollPhysics(),
               addAutomaticKeepAlives: true,
               children: [
-                    // الكلية
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        FutureBuilder(
-                            future: li.getAllProfit(),
-                            builder: (context, snapshot) {
-                              if (snapshot.hasData) {
-                                return Padding(
-                                  padding: const EdgeInsets.all(8.0),
-                                  child: Sitem(
-                                    child: Padding(
-                                      padding: const EdgeInsets.all(10.0),
-                                      child: Text(
-                                        ' الارباح الكلية : \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
-                                        //textDirection: TextDirection.rtl,
-                                      ),
-                                    ),
-                                  ),
-                                );
-                              } else {
-                                return SpinKitChasingDots(
-                                  color: Colors.brown[200],
-                                );
-                              }
-                            }),
-                        FutureBuilder(
-                          future: li.getAllSales(),
-                          builder: (context, snapshot) {
-                            if (snapshot.hasData) {
-                              return Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: Sitem(
-                                  child: Padding(
-                                    padding: const EdgeInsets.all(10.0),
-                                    child: Text(
-                                      'المبيعات الكلية  : \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
-                                      //textDirection: TextDirection.rtl,
-                                    ),
+                // الكلية
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    FutureBuilder(
+                        future: li.getAllProfit(),
+                        builder: (context, snapshot) {
+                          if (snapshot.hasData) {
+                            return Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: Sitem(
+                                child: Padding(
+                                  padding: const EdgeInsets.all(10.0),
+                                  child: Text(
+                                    ' الارباح الكلية : \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
+                                    //textDirection: TextDirection.rtl,
                                   ),
                                 ),
-                              );
-                            } else {
-                              return SpinKitChasingDots(
-                                color: Colors.brown[200],
-                              );
-                            }
-                          },
-                        )
-                      ],
-                    ),
-                    // اليومية
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        FutureBuilder(
-                          future: li.getDailyProfits(DateTime.now()),
-                          builder: (context, snapshot) {
-                            if (snapshot.hasData) {
-                              return Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: Sitem(
-                                  child: Padding(
-                                    padding: const EdgeInsets.all(10.0),
-                                    child: Text(
-                                      'الأرباح اليومية: \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
-                                      ////textDirection: TextDirection.rtl,
-                                    ),
-                                  ),
-                                ),
-                              );
-                            } else {
-                              return SpinKitChasingDots(
-                                color: Colors.brown[200],
-                              );
-                            }
-                          },
-                        ),
-                        FutureBuilder(
-                          future: li.getDailySales(DateTime.now()),
-                          builder: (context, snapshot) {
-                            if (snapshot.hasData) {
-                              return Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: Sitem(
-                                  child: Padding(
-                                    padding: const EdgeInsets.all(10.0),
-                                    child: Text(
-                                      'المبيعات اليومية: \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
-                                      ////textDirection: TextDirection.rtl,
-                                    ),
-                                  ),
-                                ),
-                              );
-                            } else {
-                              return SpinKitChasingDots(
-                                color: Colors.brown[200],
-                              );
-                            }
-                          },
-                        ),
-                      ],
-                    ),
-                    // الشهرية
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        FutureBuilder(
-                          future: li.getProfitOfTheMonth(),
-                          builder: (context, snapshot) {
-                            if (snapshot.hasData) {
-                              return Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: Sitem(
-                                  child: Padding(
-                                    padding: const EdgeInsets.all(10.0),
-                                    child: Text(
-                                      'الأرباح الشهرية: \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
-                                      ////textDirection: TextDirection.rtl,
-                                    ),
-                                  ),
-                                ),
-                              );
-                            } else {
-                              return SpinKitChasingDots(
-                                color: Colors.brown[200],
-                              );
-                            }
-                          },
-                        ),
-                        FutureBuilder(
-                          future: li.getSalesOfTheMonth(),
-                          builder: (context, snapshot) {
-                            if (snapshot.hasData) {
-                              return Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: Sitem(
-                                  child: Padding(
-                                    padding: const EdgeInsets.all(10.0),
-                                    child: Text(
-                                      'المبيعات الشهرية: \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
-                                      ////textDirection: TextDirection.rtl,
-                                    ),
-                                  ),
-                                ),
-                              );
-                            } else {
-                              return SpinKitChasingDots(
-                                color: Colors.brown[200],
-                              );
-                            }
-                          },
-                        ),
-                      ],
-                    ),
-                    // متوسط الارباح
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        FutureBuilder(
-                          future: li.getAverageProfitPercent(),
-                          builder: (context, snapshot) {
-                            if (snapshot.hasData) {
-                              return Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: Sitem(
-                                  child: Padding(
-                                    padding: const EdgeInsets.all(10.0),
-                                    child: Text(
-                                      ' متوسط نسبة الأرباح العامة: \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
-                                      ////textDirection: TextDirection.rtl,
-                                    ),
-                                  ),
-                                ),
-                              );
-                            } else {
-                              return SpinKitChasingDots(
-                                color: Colors.brown[200],
-                              );
-                            }
-                          },
-                        ),
-                      ],
-                    ),
-                    // daily saled products chart
-                    Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: Container(
-                          height: 300,
-                          decoration: BoxDecoration(
+                              ),
+                            );
+                          } else {
+                            return SpinKitChasingDots(
                               color: Colors.brown[200],
-                              borderRadius: BorderRadius.circular(12)),
-                          child: ChangeNotifierProvider.value(
-                            value: li,
-                            child: const CircularChart(),
-                          )),
-                    ),
-                    // total sales per product
-                    Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: Container(
-                          height: 300,
-                          constraints: const BoxConstraints(
-                            maxWidth: 200,
-                          ),
-                          decoration: BoxDecoration(
-                              color: Colors.brown[200],
-                              borderRadius: BorderRadius.circular(12)),
-                          child: ChangeNotifierProvider.value(
-                            value: li,
-                            child: const BarChart(),
-                          )),
-                    ),
-                    // total sales for each day in the month
-                    Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: Container(
-                          // height: 650,
-                          constraints: const BoxConstraints(
-                            maxWidth: 200,
-                          ),
-                          decoration: BoxDecoration(
+                            );
+                          }
+                        }),
+                    FutureBuilder(
+                      future: li.getAllSales(),
+                      builder: (context, snapshot) {
+                        if (snapshot.hasData) {
+                          return Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Sitem(
+                              child: Padding(
+                                padding: const EdgeInsets.all(10.0),
+                                child: Text(
+                                  'المبيعات الكلية  : \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
+                                  //textDirection: TextDirection.rtl,
+                                ),
+                              ),
+                            ),
+                          );
+                        } else {
+                          return SpinKitChasingDots(
                             color: Colors.brown[200],
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: ChangeNotifierProvider.value(
-                            value: li,
-                            child: const LineChart(),
-                          )),
-                    ),
-                    // monthly sales of the year
-                    Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: Container(
-                          // height: 650,
-                          constraints: const BoxConstraints(
-                            maxWidth: 200,
-                          ),
-                          decoration: BoxDecoration(
+                          );
+                        }
+                      },
+                    )
+                  ],
+                ),
+                // اليومية
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    FutureBuilder(
+                      future: li.getDailyProfits(DateTime.now()),
+                      builder: (context, snapshot) {
+                        if (snapshot.hasData) {
+                          return Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Sitem(
+                              child: Padding(
+                                padding: const EdgeInsets.all(10.0),
+                                child: Text(
+                                  'الأرباح اليومية: \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
+                                  ////textDirection: TextDirection.rtl,
+                                ),
+                              ),
+                            ),
+                          );
+                        } else {
+                          return SpinKitChasingDots(
                             color: Colors.brown[200],
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: ChangeNotifierProvider.value(
-                            value: li,
-                            child: const MOY(),
-                          )),
+                          );
+                        }
+                      },
                     ),
-                    // owners list
-                    Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: Container(
-                        height: 300,
-                        constraints: const BoxConstraints(
-                          maxWidth: 200,
-                        ),
-                        decoration: BoxDecoration(
+                    FutureBuilder(
+                      future: li.getDailySales(DateTime.now()),
+                      builder: (context, snapshot) {
+                        if (snapshot.hasData) {
+                          return Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Sitem(
+                              child: Padding(
+                                padding: const EdgeInsets.all(10.0),
+                                child: Text(
+                                  'المبيعات اليومية: \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
+                                  ////textDirection: TextDirection.rtl,
+                                ),
+                              ),
+                            ),
+                          );
+                        } else {
+                          return SpinKitChasingDots(
                             color: Colors.brown[200],
-                            borderRadius: BorderRadius.circular(12)),
-                        child: ChangeNotifierProvider.value(
-                          value: li,
-                          child: Ownertile(),
-                        ),
-                      ),
+                          );
+                        }
+                      },
                     ),
                   ],
                 ),
-              ),
-            ],
+                // الشهرية
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    FutureBuilder(
+                      future: li.getProfitOfTheMonth(),
+                      builder: (context, snapshot) {
+                        if (snapshot.hasData) {
+                          return Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Sitem(
+                              child: Padding(
+                                padding: const EdgeInsets.all(10.0),
+                                child: Text(
+                                  'الأرباح الشهرية: \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
+                                  ////textDirection: TextDirection.rtl,
+                                ),
+                              ),
+                            ),
+                          );
+                        } else {
+                          return SpinKitChasingDots(
+                            color: Colors.brown[200],
+                          );
+                        }
+                      },
+                    ),
+                    FutureBuilder(
+                      future: li.getSalesOfTheMonth(),
+                      builder: (context, snapshot) {
+                        if (snapshot.hasData) {
+                          return Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Sitem(
+                              child: Padding(
+                                padding: const EdgeInsets.all(10.0),
+                                child: Text(
+                                  'المبيعات الشهرية: \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
+                                  ////textDirection: TextDirection.rtl,
+                                ),
+                              ),
+                            ),
+                          );
+                        } else {
+                          return SpinKitChasingDots(
+                            color: Colors.brown[200],
+                          );
+                        }
+                      },
+                    ),
+                  ],
+                ),
+                // متوسط الارباح
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    FutureBuilder(
+                      future: li.getAverageProfitPercent(),
+                      builder: (context, snapshot) {
+                        if (snapshot.hasData) {
+                          return Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Sitem(
+                              child: Padding(
+                                padding: const EdgeInsets.all(10.0),
+                                child: Text(
+                                  ' متوسط نسبة الأرباح العامة: \n ${NumberFormat.simpleCurrency().format(snapshot.data)}',
+                                  ////textDirection: TextDirection.rtl,
+                                ),
+                              ),
+                            ),
+                          );
+                        } else {
+                          return SpinKitChasingDots(
+                            color: Colors.brown[200],
+                          );
+                        }
+                      },
+                    ),
+                  ],
+                ),
+                // daily saled products chart
+                Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: Container(
+                      height: 300,
+                      decoration: BoxDecoration(
+                          color: Colors.brown[200],
+                          borderRadius: BorderRadius.circular(12)),
+                      child: ChangeNotifierProvider.value(
+                        value: li,
+                        child: CircularChart(),
+                      )),
+                ),
+                // total sales per product
+                Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: Container(
+                      height: 300,
+                      constraints: const BoxConstraints(
+                        maxWidth: 200,
+                      ),
+                      decoration: BoxDecoration(
+                          color: Colors.brown[200],
+                          borderRadius: BorderRadius.circular(12)),
+                      child: ChangeNotifierProvider.value(
+                        value: li,
+                        child: BarChart(),
+                      )),
+                ),
+                // total sales for each day in the month
+                Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: Container(
+                      // height: 650,
+                      constraints: const BoxConstraints(
+                        maxWidth: 200,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Colors.brown[200],
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: ChangeNotifierProvider.value(
+                        value: li,
+                        child: LineChart(),
+                      )),
+                ),
+                // monthly sales of the year
+                Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: Container(
+                      // height: 650,
+                      constraints: const BoxConstraints(
+                        maxWidth: 200,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Colors.brown[200],
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: ChangeNotifierProvider.value(
+                        value: li,
+                        child: MOY(),
+                      )),
+                ),
+                // owners list
+                Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: Container(
+                    height: 300,
+                    constraints: const BoxConstraints(
+                      maxWidth: 200,
+                    ),
+                    decoration: BoxDecoration(
+                        color: Colors.brown[200],
+                        borderRadius: BorderRadius.circular(12)),
+                    child: ChangeNotifierProvider.value(
+                      value: li,
+                      child: Ownertile(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
-          floatingActionButton: FloatingActionButton(
-            onPressed: () {
-              sc.animateTo(
-                sc.position.maxScrollExtent,
-                duration: Duration(seconds: 2),
-                curve: Curves.fastOutSlowIn,
-              );
-            },
-            child: Icon(Icons.arrow_downward_rounded),
-          ),
-        );
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          _scrollController.animateTo(
+            _scrollController.position.maxScrollExtent,
+            duration: const Duration(seconds: 2),
+            curve: Curves.fastOutSlowIn,
+          );
+        },
+        child: const Icon(Icons.arrow_downward_rounded),
+      ),
+    );
   }
 }

--- a/lib/providers/list.dart
+++ b/lib/providers/list.dart
@@ -83,8 +83,11 @@ class Lists extends ChangeNotifier with LanSyncState {
     return result;
   }
 
+  int cacheVersion = 0;
+
   void clearAllCache() {
     _cache.clear();
+    cacheVersion++;
     notifyListeners();
   }
 

--- a/lib/util/charts.dart
+++ b/lib/util/charts.dart
@@ -45,8 +45,9 @@ class _CircularChartState extends State<CircularChart>
           mainAxisSize: MainAxisSize.min,
           direction: Axis.vertical,
           children: [
-            Consumer<Lists>(
-              builder: (context, li, child) {
+            Builder(
+              builder: (context) {
+                final li = context.read<Lists>();
                 return Flexible(
                   child: FutureBuilder(
                       future: li.getSaledProductsByDate(time),
@@ -181,57 +182,60 @@ class _BarChartState extends State<BarChart>
         mainAxisSize: MainAxisSize.min,
         direction: Axis.vertical,
         children: [
-          Flexible(
-            child: Consumer<Lists>(
-              builder: (context, li, child) => FutureBuilder(
-                  future: future,
-                  builder: (context, snapshot) {
-                    if (snapshot.hasError) {
-                      return const Text(UserSafeMessages.loadFailed);
-                    }
-                    if (snapshot.hasData) {
-                      if (_scrollController.position.pixels ==
-                          _scrollController.position.maxScrollExtent) {
-                        // Show a loading indicator at the bottom when fetching more data
+          Builder(
+            builder: (context) {
+              return Flexible(
+                child: FutureBuilder(
+                    future: future,
+                    builder: (context, snapshot) {
+                      if (snapshot.hasError) {
+                        return const Text(UserSafeMessages.loadFailed);
                       }
-                      return SizedBox(
-                        height: snapshot.data!.length * 60.0 > 200
-                            ? snapshot.data!.length * 60
-                            : 200,
-                        child: SfCartesianChart(
-                          title: ChartTitle(
-                              text: 'المبيعات لكل منتج',
-                              alignment: ChartAlignment.near),
-                          primaryXAxis: CategoryAxis(),
-                          primaryYAxis: NumericAxis(
-                            numberFormat: NumberFormat.compact(),
-                            isVisible: true,
-                          ),
-                          tooltipBehavior: TooltipBehavior(enable: _tooltipReady),
-                          series: <CartesianSeries>[
-                            StackedBarSeries<ProdStats, String>(
-                              animationDuration: 0,
-                              borderRadius: BorderRadius.circular(12),
-                              color: Colors.brown,
-                              dataSource: snapshot.data!,
-                              xValueMapper: (ProdStats data, _) => data.name,
-                              yValueMapper: (ProdStats data, _) => data.count,
-                              dataLabelSettings: const DataLabelSettings(
-                                isVisible: true,
-                              ),
+                      if (snapshot.hasData) {
+                        if (_scrollController.position.pixels ==
+                            _scrollController.position.maxScrollExtent) {
+                          // Show a loading indicator at the bottom when fetching more data
+                        }
+                        return SizedBox(
+                          height: snapshot.data!.length * 60.0 > 200
+                              ? snapshot.data!.length * 60
+                              : 200,
+                          child: SfCartesianChart(
+                            title: ChartTitle(
+                                text: 'المبيعات لكل منتج',
+                                alignment: ChartAlignment.near),
+                            primaryXAxis: CategoryAxis(),
+                            primaryYAxis: NumericAxis(
+                              numberFormat: NumberFormat.compact(),
+                              isVisible: true,
                             ),
-                          ],
-                        ),
-                      );
-                    } else {
-                      return Center(
-                        child: SpinKitChasingDots(
-                          color: Colors.white,
-                        ),
-                      );
-                    }
-                  }),
-            ),
+                            tooltipBehavior:
+                                TooltipBehavior(enable: _tooltipReady),
+                            series: <CartesianSeries>[
+                              StackedBarSeries<ProdStats, String>(
+                                animationDuration: 0,
+                                borderRadius: BorderRadius.circular(12),
+                                color: Colors.brown,
+                                dataSource: snapshot.data!,
+                                xValueMapper: (ProdStats data, _) => data.name,
+                                yValueMapper: (ProdStats data, _) => data.count,
+                                dataLabelSettings: const DataLabelSettings(
+                                  isVisible: true,
+                                ),
+                              ),
+                            ],
+                          ),
+                        );
+                      } else {
+                        return Center(
+                          child: SpinKitChasingDots(
+                            color: Colors.white,
+                          ),
+                        );
+                      }
+                    }),
+              );
+            },
           ),
           _isLoadingMore
               ? Padding(
@@ -294,8 +298,9 @@ class _LineChartState extends State<LineChart>
           });
         });
       },
-      child: Consumer<Lists>(
-        builder: (context, li, child) {
+      child: Builder(
+        builder: (context) {
+          final li = context.read<Lists>();
           return FutureBuilder(
               future: Future.wait(
                 [
@@ -437,8 +442,9 @@ class _MOYState extends State<MOY>
           });
         });
       },
-      child: Consumer<Lists>(
-        builder: (context, li, child) {
+      child: Builder(
+        builder: (context) {
+          final li = context.read<Lists>();
           return FutureBuilder(
               future: Future.wait([
                 li.getMonthlySalesOfTheYear(time),
@@ -552,7 +558,7 @@ class _OwnertileState extends State<Ownertile>
     super.build(context);
 
     return FutureBuilder(
-      future: Provider.of<Lists>(context).refreshListOfOwners(),
+      future: context.read<Lists>().refreshListOfOwners(),
       builder: (context, snapshot) {
         if (snapshot.hasError) {
           return const Text(UserSafeMessages.loadFailed);
@@ -627,24 +633,23 @@ class _OwnertileState extends State<Ownertile>
                       keyboardType: TextInputType.number,
                     ),
                   ),
-                  Consumer<Lists>(
-                    builder: (context, li, child) => IconButton(
-                      onPressed: () {
-                        if (payCon.text.isNotEmpty) {
-                          li.ownersList.elementAt(index).totalPayed +=
-                              double.parse(payCon.text);
-                          li.ownersList.elementAt(index).dueMoney -=
-                              double.parse(payCon.text);
-                          li.ownersList.elementAt(index).lastPaymentDate =
-                              DateTime.now();
-                          li.ownersList.elementAt(index).lastPayment =
-                              double.parse(payCon.text);
-                          li.updateOwner(li.ownersList.elementAt(index));
-                          li.refresh();
-                        }
-                      },
-                      icon: const Icon(Icons.payments_outlined),
-                    ),
+                  IconButton(
+                    onPressed: () {
+                      if (payCon.text.isNotEmpty) {
+                        final li = context.read<Lists>();
+                        li.ownersList.elementAt(index).totalPayed +=
+                            double.parse(payCon.text);
+                        li.ownersList.elementAt(index).dueMoney -=
+                            double.parse(payCon.text);
+                        li.ownersList.elementAt(index).lastPaymentDate =
+                            DateTime.now();
+                        li.ownersList.elementAt(index).lastPayment =
+                            double.parse(payCon.text);
+                        li.updateOwner(li.ownersList.elementAt(index));
+                        li.refresh();
+                      }
+                    },
+                    icon: const Icon(Icons.payments_outlined),
                   ),
                 ],
               );

--- a/lib/util/loan.dart
+++ b/lib/util/loan.dart
@@ -702,9 +702,9 @@ class _LoanState extends State<Loan> {
                             if (type == 'reset') {
                               balanceBefore = null;
                             } else if (type == 'withdraw') {
-                              balanceBefore = remaining! - value;
+                              balanceBefore = (remaining ?? 0) - value;
                             } else {
-                              balanceBefore = remaining! + value;
+                              balanceBefore = (remaining ?? 0) + value;
                             }
 
                             Color typeColor;
@@ -738,7 +738,7 @@ class _LoanState extends State<Loan> {
                                                   .format(value),
                                           date: paymentDate,
                                           name: name!,
-                                          remaining: remaining!,
+                                          remaining: remaining ?? 0,
                                           clearField: () {},
                                           type: type),
                                     ));

--- a/lib/util/models/Product.dart
+++ b/lib/util/models/Product.dart
@@ -78,8 +78,6 @@ class Product {
     if (name == null || name!.trim().isEmpty) return 'Product name is required';
     if (ownerName == null || ownerName!.trim().isEmpty)
       return 'Owner is required';
-    if (barcode == null || barcode!.trim().isEmpty)
-      return 'Barcode is required';
     if (buyprice == null || buyprice! < 0)
       return 'Buy price must be non-negative';
     if (sellPrice == null || sellPrice! < 0)

--- a/test/integration/product_validation_test.dart
+++ b/test/integration/product_validation_test.dart
@@ -18,11 +18,6 @@ void main() {
           productFixture(ownerName: '').validateForCreate(), contains('Owner'));
     });
 
-    test('requires barcode', () {
-      expect(
-          productFixture(barcode: '').validateForCreate(), contains('Barcode'));
-    });
-
     test('rejects negative buy price', () {
       expect(productFixture(buyPrice: -1).validateForCreate(), contains('Buy'));
     });

--- a/test/widget/real_widgets_test.dart
+++ b/test/widget/real_widgets_test.dart
@@ -83,7 +83,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
 
-    expect(find.text('أدخل قيم صحيحة'), findsOneWidget);
+    expect(find.text('خطأ في الإدخال'), findsOneWidget);
     await tester.pumpWidget(const SizedBox.shrink());
   });
 


### PR DESCRIPTION
- Fix null check crash in payment history by replacing `remaining!` with `(remaining ?? 0)` across three locations in loan.dart
- Remove barcode from mandatory product validation (optional field)
- Show specific validation error messages in dialogs instead of generic "ادخل قيم صحيحة"
- Add per-field numeric validation for buy/sell/count/offer inputs with clear Arabic error messages
- Stop stats page and chart widgets from rebuilding when a sale completes while user is on the sell tab; refresh only on tab switch via cache version detection