### PR TITLE
v2.4.18 Enhance loaner comparison with horizontal chart and profit/loss features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable production-readiness changes are tracked here.
 
+## 2.4.17
+
+- Loaner debt window now counts hot products at sell price (`logLoanedValue`), so the window/current value step correctly.
+- Replaced the loaner comparison chart with a diverging profit/loss chart (green = loaner still owes tracked value, red = loaner overpaid).
+- Fixed null-offer crash when editing a receipt that contains hot products.
+- Fixed buy/sell mismatch: editing or canceling a receipt now subtracts hot products at sell price, matching checkout.
+- Sell page now refreshes immediately after a receipt edit restores products to the cart.
+
 ## 2.4.16
 
 - Fixed monthly loans calculation: credit sales no longer double-counted as payments in `_calculateTotalPayments`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable production-readiness changes are tracked here.
 
+## 2.4.18
+
+- Inventory page now refreshes deterministically after editing a product: the DB write is awaited before listeners are notified, removing the intermittent stale-tile race.
+- New products added from the inventory page now appear in the grid immediately (insert also notifies inventory listeners after persisting).
+
 ## 2.4.17
 
 - Loaner debt window now counts hot products at sell price (`logLoanedValue`), so the window/current value step correctly.

--- a/factcheck/fact_check_test.dart
+++ b/factcheck/fact_check_test.dart
@@ -5,6 +5,12 @@
 // window) and cross-checks the result against computeLoanerComparison, the
 // exact function that feeds the chart.
 //
+// Hot products are not tracked in the product catalog (no reliable buy price),
+// so they are excluded from both sides of the chart. Their sell value is
+// reported separately so a loaner's balance can be reconciled:
+//
+//   tracked loaned (chart) + hot = balance
+//
 // Run it on demand against the real data:
 //
 //   DUKKAN_DB_DIR=/path/to/db/folder \
@@ -15,10 +21,11 @@
 //
 // The database is copied to a temp dir before opening, so real data is never
 // touched and the check works while the app is running.
+// ignore_for_file: invalid_use_of_visible_for_testing_member
 import 'dart:io';
 
-// ignore: invalid_use_of_visible_for_testing_member
-import 'package:dukkan/core/db.dart' show computeLoanerComparison;
+import 'package:dukkan/core/db.dart'
+    show computeLoanerComparison, hotSellValue, logLoanedValue;
 import 'package:dukkan/util/models/Expense.dart';
 import 'package:dukkan/util/models/Log.dart';
 import 'package:dukkan/util/models/Loaner.dart';
@@ -36,8 +43,10 @@ final _df = DateFormat('yyyy-MM-dd');
 class _LineCheck {
   final Log log;
   final double price;
+  final double hot;
   final double recomputed;
-  final double loanedAmount;
+  final double trackedAmount;
+  final double hotAmount;
   final double currentValue;
   final double fraction;
   final bool boundary;
@@ -45,14 +54,16 @@ class _LineCheck {
   _LineCheck({
     required this.log,
     required this.price,
+    required this.hot,
     required this.recomputed,
-    required this.loanedAmount,
+    required this.trackedAmount,
+    required this.hotAmount,
     required this.currentValue,
     required this.fraction,
     required this.boundary,
   });
 
-  bool get priceDiffers => (price - recomputed).abs() > 0.01;
+  bool get priceDiffers => (price + hot - recomputed).abs() > 0.01;
 }
 
 class _LoanerCheck {
@@ -60,7 +71,8 @@ class _LoanerCheck {
   final Id id;
   final double balance;
   final List<_LineCheck> lines;
-  final double loanedAmount;
+  final double trackedAmount;
+  final double hotAmount;
   final double currentValue;
 
   _LoanerCheck({
@@ -68,12 +80,13 @@ class _LoanerCheck {
     required this.id,
     required this.balance,
     required this.lines,
-    required this.loanedAmount,
+    required this.trackedAmount,
+    required this.hotAmount,
     required this.currentValue,
   });
 }
 
-bool _feq(double a, double b) => (a - b).abs() < 0.01;
+bool _feq(double a, double b, {double tol = 0.01}) => (a - b).abs() <= tol;
 
 double _currentValue(Log log, Map<int, Product> productMap) {
   double value = 0;
@@ -103,28 +116,37 @@ _LoanerCheck _manualWalk(
 ) {
   final sorted = [...logs]..sort((a, b) => b.date.compareTo(a.date));
   final lines = <_LineCheck>[];
-  double loaned = 0;
+  double tracked = 0;
+  double hot = 0;
   double current = 0;
   var remaining = loaner.balance ?? 0;
 
   for (final log in sorted) {
     final price = log.price;
-    if (price <= 0) continue;
+    final hotValue = hotSellValue(log);
+    final value = logLoanedValue(log);
     final currentValue = _currentValue(log, productMap);
     final recomputed = _recomputePrice(log);
 
-    if (remaining <= price) {
-      final fraction = remaining / price;
+    if (value <= 0) {
+      continue;
+    }
+
+    if (remaining <= value) {
+      final fraction = remaining / value;
       lines.add(_LineCheck(
         log: log,
         price: price,
+        hot: hotValue,
         recomputed: recomputed,
-        loanedAmount: price * fraction,
+        trackedAmount: price * fraction,
+        hotAmount: hotValue * fraction,
         currentValue: currentValue * fraction,
         fraction: fraction,
         boundary: true,
       ));
-      loaned += price * fraction;
+      tracked += price * fraction;
+      hot += hotValue * fraction;
       current += currentValue * fraction;
       break;
     }
@@ -132,15 +154,18 @@ _LoanerCheck _manualWalk(
     lines.add(_LineCheck(
       log: log,
       price: price,
+      hot: hotValue,
       recomputed: recomputed,
-      loanedAmount: price,
+      trackedAmount: price,
+      hotAmount: hotValue,
       currentValue: currentValue,
       fraction: 1,
       boundary: false,
     ));
-    loaned += price;
+    tracked += price;
+    hot += hotValue;
     current += currentValue;
-    remaining -= price;
+    remaining -= value;
   }
 
   return _LoanerCheck(
@@ -148,7 +173,8 @@ _LoanerCheck _manualWalk(
     id: loaner.ID,
     balance: loaner.balance ?? 0,
     lines: lines,
-    loanedAmount: loaned,
+    trackedAmount: tracked,
+    hotAmount: hot,
     currentValue: current,
   );
 }
@@ -233,21 +259,26 @@ void _printReport(_LoanerCheck c, LoanerComparison? chart) {
     final mark =
         line.boundary ? 'جزئي ${_nf.format(line.fraction)}' : 'full';
     print('    ${_df.format(line.log.date)}  '
-        'loaned ${_nf.format(line.loanedAmount)}  '
+        'tracked ${_nf.format(line.trackedAmount)}  '
+        'hot ${_nf.format(line.hotAmount)}  '
         'current ${_nf.format(line.currentValue)}  [$mark]');
     if (line.priceDiffers) {
-      print('      ⚠ stored price ${_nf.format(line.price)} '
+      print('      ⚠ stored tracked+hot ${_nf.format(line.price + line.hot)} '
           '!= Σ(sell×count)-discount ${_nf.format(line.recomputed)} '
           '(offer bundle? verify manually)');
     }
   }
   print('  ──');
-  final balanceOk = _feq(c.loanedAmount, c.balance);
-  print('  Σ loaned  ${_nf.format(c.loanedAmount)}  ==  balance '
-      '${_nf.format(c.balance)}  ${balanceOk ? '✓' : '✗ MISMATCH'}');
-  print('  Σ current ${_nf.format(c.currentValue)}');
+  final sum = c.trackedAmount + c.hotAmount;
+  final balanceOk = _feq(sum, c.balance, tol: 1.0);
+  print('  Σ tracked (chart loanedAmount)  ${_nf.format(c.trackedAmount)}');
+  print('  Σ hot (untracked, no buy price) ${_nf.format(c.hotAmount)}');
+  print('  tracked + hot                   ${_nf.format(sum)}  '
+      '==  balance ${_nf.format(c.balance)}  '
+      '${balanceOk ? '✓' : '✗ MISMATCH (diff ${_nf.format(sum - c.balance)})'}');
+  print('  Σ current                       ${_nf.format(c.currentValue)}');
   if (chart != null) {
-    final ok = _feq(chart.loanedAmount, c.loanedAmount) &&
+    final ok = _feq(chart.loanedAmount, c.trackedAmount) &&
         _feq(chart.currentValue, c.currentValue);
     print('  chart     loaned ${_nf.format(chart.loanedAmount)}  '
         'current ${_nf.format(chart.currentValue)}  '
@@ -312,7 +343,7 @@ void main() {
           checks.add(_manualWalk(loaner, loanerLogs, productMap));
         }
 
-        final chart = computeLoanerComparison( // ignore: invalid_use_of_visible_for_testing_member
+        final chart = computeLoanerComparison(
           loaners: eligible,
           loanedLogs: logs,
           productMap: productMap,
@@ -329,19 +360,29 @@ void main() {
           final chartRes = chartByName[check.name];
           _printReport(check, chartRes);
 
-          if (!_feq(check.loanedAmount, check.balance)) {
-            failures.add('${check.name}: loanedAmount '
-                '${_nf.format(check.loanedAmount)} != balance '
-                '${_nf.format(check.balance)}');
+          final sum = check.trackedAmount + check.hotAmount;
+          if (!_feq(sum, check.balance, tol: 1.0)) {
+            failures.add('${check.name}: tracked+hot '
+                '${_nf.format(sum)} != balance ${_nf.format(check.balance)} '
+                '(diff ${_nf.format(sum - check.balance)})');
           }
           if (chartRes == null) {
-            failures.add(
-                '${check.name}: missing from chart output (no owing logs?)');
+            final purelyHot = check.trackedAmount == 0 &&
+                check.currentValue == 0 &&
+                check.hotAmount > 0;
+            if (purelyHot) {
+              // ignore: avoid_print
+              print('  chart     absent (entirely hot debt, no buy price) — '
+                  'expected');
+            } else {
+              failures.add(
+                  '${check.name}: missing from chart output (no owing logs?)');
+            }
           } else {
-            if (!_feq(chartRes.loanedAmount, check.loanedAmount)) {
+            if (!_feq(chartRes.loanedAmount, check.trackedAmount)) {
               failures.add('${check.name}: chart loanedAmount '
-                  '${_nf.format(chartRes.loanedAmount)} != manual '
-                  '${_nf.format(check.loanedAmount)}');
+                  '${_nf.format(chartRes.loanedAmount)} != manual tracked '
+                  '${_nf.format(check.trackedAmount)}');
             }
             if (!_feq(chartRes.currentValue, check.currentValue)) {
               failures.add('${check.name}: chart currentValue '

--- a/factcheck/fact_check_test.dart
+++ b/factcheck/fact_check_test.dart
@@ -1,0 +1,368 @@
+// One-time external fact-check for the loaner comparison chart.
+//
+// Recomputes each owing loaner's loanedAmount and currentValue directly from
+// the real Isar database (using an independent manual walk of the debt
+// window) and cross-checks the result against computeLoanerComparison, the
+// exact function that feeds the chart.
+//
+// Run it on demand against the real data:
+//
+//   DUKKAN_DB_DIR=/path/to/db/folder \
+//     flutter test factcheck/fact_check_test.dart
+//
+// The folder must contain `isarInstance.isar`. If DUKKAN_DB_DIR is unset the
+// check tries common local locations and prints usage otherwise.
+//
+// The database is copied to a temp dir before opening, so real data is never
+// touched and the check works while the app is running.
+import 'dart:io';
+
+// ignore: invalid_use_of_visible_for_testing_member
+import 'package:dukkan/core/db.dart' show computeLoanerComparison;
+import 'package:dukkan/util/models/Expense.dart';
+import 'package:dukkan/util/models/Log.dart';
+import 'package:dukkan/util/models/Loaner.dart';
+import 'package:dukkan/util/models/Owner.dart';
+import 'package:dukkan/util/models/Product.dart';
+import 'package:dukkan/util/models/prodStats.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:isar_community/isar.dart';
+
+const _dbFileName = 'isarInstance.isar';
+final _nf = NumberFormat('#,##0.###');
+final _df = DateFormat('yyyy-MM-dd');
+
+class _LineCheck {
+  final Log log;
+  final double price;
+  final double recomputed;
+  final double loanedAmount;
+  final double currentValue;
+  final double fraction;
+  final bool boundary;
+
+  _LineCheck({
+    required this.log,
+    required this.price,
+    required this.recomputed,
+    required this.loanedAmount,
+    required this.currentValue,
+    required this.fraction,
+    required this.boundary,
+  });
+
+  bool get priceDiffers => (price - recomputed).abs() > 0.01;
+}
+
+class _LoanerCheck {
+  final String name;
+  final Id id;
+  final double balance;
+  final List<_LineCheck> lines;
+  final double loanedAmount;
+  final double currentValue;
+
+  _LoanerCheck({
+    required this.name,
+    required this.id,
+    required this.balance,
+    required this.lines,
+    required this.loanedAmount,
+    required this.currentValue,
+  });
+}
+
+bool _feq(double a, double b) => (a - b).abs() < 0.01;
+
+double _currentValue(Log log, Map<int, Product> productMap) {
+  double value = 0;
+  for (final ep in log.products) {
+    if (ep.hot == true) continue;
+    final count = ep.count ?? 0;
+    final buyPrice = (ep.productId != null && ep.productId! > 0)
+        ? (productMap[ep.productId]?.buyprice ?? (ep.buyPrice ?? 0))
+        : (ep.buyPrice ?? 0);
+    value += buyPrice * count;
+  }
+  return value;
+}
+
+double _recomputePrice(Log log) {
+  final sum = log.products.fold<double>(
+    0,
+    (total, ep) => total + ((ep.sellPrice ?? 0) * (ep.count ?? 0)),
+  );
+  return sum - log.discount;
+}
+
+_LoanerCheck _manualWalk(
+  Loaner loaner,
+  List<Log> logs,
+  Map<int, Product> productMap,
+) {
+  final sorted = [...logs]..sort((a, b) => b.date.compareTo(a.date));
+  final lines = <_LineCheck>[];
+  double loaned = 0;
+  double current = 0;
+  var remaining = loaner.balance ?? 0;
+
+  for (final log in sorted) {
+    final price = log.price;
+    if (price <= 0) continue;
+    final currentValue = _currentValue(log, productMap);
+    final recomputed = _recomputePrice(log);
+
+    if (remaining <= price) {
+      final fraction = remaining / price;
+      lines.add(_LineCheck(
+        log: log,
+        price: price,
+        recomputed: recomputed,
+        loanedAmount: price * fraction,
+        currentValue: currentValue * fraction,
+        fraction: fraction,
+        boundary: true,
+      ));
+      loaned += price * fraction;
+      current += currentValue * fraction;
+      break;
+    }
+
+    lines.add(_LineCheck(
+      log: log,
+      price: price,
+      recomputed: recomputed,
+      loanedAmount: price,
+      currentValue: currentValue,
+      fraction: 1,
+      boundary: false,
+    ));
+    loaned += price;
+    current += currentValue;
+    remaining -= price;
+  }
+
+  return _LoanerCheck(
+    name: loaner.name ?? 'Unknown',
+    id: loaner.ID,
+    balance: loaner.balance ?? 0,
+    lines: lines,
+    loanedAmount: loaned,
+    currentValue: current,
+  );
+}
+
+Directory? _resolveDbDir() {
+  final fromEnv = Platform.environment['DUKKAN_DB_DIR'];
+  if (fromEnv != null && fromEnv.isNotEmpty) {
+    final dir = Directory(fromEnv);
+    if (dir.existsSync() &&
+        dir.listSync().any((e) => e is File && e.path.endsWith('.isar'))) {
+      return dir;
+    }
+  }
+
+  final home = Platform.environment['HOME'] ?? '';
+  const candidates = [
+    '/Documents',
+    '/.local/share/dukkan',
+    '/.local/share/com.golden.dukkan',
+  ];
+  for (final suffix in candidates) {
+    final dir = Directory('$home$suffix');
+    if (dir.existsSync() &&
+        dir.listSync().any((e) => e is File && e.path.endsWith('.isar'))) {
+      return dir;
+    }
+  }
+  return null;
+}
+
+Future<void> _copyDir(Directory source, Directory target) async {
+  await target.create(recursive: true);
+  for (final entity in source.listSync()) {
+    final name = entity.uri.pathSegments.last;
+    final dest = '${target.path}/$name';
+    if (entity is Directory) {
+      await _copyDir(entity, Directory(dest));
+    } else if (entity is File) {
+      await entity.copy(dest);
+    }
+  }
+}
+
+Future<Directory> _copyDbToTemp(Directory source) async {
+  final tmp = await Directory.systemTemp.createTemp('dukkan_factcheck_');
+  await _copyDir(source, tmp);
+  for (final entity in tmp.listSync(recursive: true)) {
+    if (entity is! File) continue;
+    final name = entity.uri.pathSegments.last;
+    if (name.endsWith('.lock') ||
+        name.endsWith('.tmp') ||
+        name.endsWith('.wal') ||
+        name.endsWith('.shm')) {
+      await entity.delete();
+    }
+  }
+  return tmp;
+}
+
+void _printUsage() {
+  // ignore: avoid_print
+  print('''
+DUKKAN fact-check: no Isar database found.
+
+Point the check at the real database folder (the one containing
+'$_dbFileName') with the DUKKAN_DB_DIR environment variable:
+
+  DUKKAN_DB_DIR=/path/to/db/folder flutter test factcheck/fact_check_test.dart
+
+On Android the database lives in the app's files directory. Pull it with adb
+(e.g. via `adb run-as com.golden.dukkan` on a debuggable build, or a full
+device backup) and point DUKKAN_DB_DIR at the extracted folder.
+''');
+}
+
+void _printReport(_LoanerCheck c, LoanerComparison? chart) {
+  print('══════════════════════════════════════════════════════════════');
+  print('${c.name}  (id ${c.id})');
+  print('  balance (recorded):  ${_nf.format(c.balance)}');
+  print('  debt window (newest -> oldest):');
+  for (final line in c.lines) {
+    final mark =
+        line.boundary ? 'جزئي ${_nf.format(line.fraction)}' : 'full';
+    print('    ${_df.format(line.log.date)}  '
+        'loaned ${_nf.format(line.loanedAmount)}  '
+        'current ${_nf.format(line.currentValue)}  [$mark]');
+    if (line.priceDiffers) {
+      print('      ⚠ stored price ${_nf.format(line.price)} '
+          '!= Σ(sell×count)-discount ${_nf.format(line.recomputed)} '
+          '(offer bundle? verify manually)');
+    }
+  }
+  print('  ──');
+  final balanceOk = _feq(c.loanedAmount, c.balance);
+  print('  Σ loaned  ${_nf.format(c.loanedAmount)}  ==  balance '
+      '${_nf.format(c.balance)}  ${balanceOk ? '✓' : '✗ MISMATCH'}');
+  print('  Σ current ${_nf.format(c.currentValue)}');
+  if (chart != null) {
+    final ok = _feq(chart.loanedAmount, c.loanedAmount) &&
+        _feq(chart.currentValue, c.currentValue);
+    print('  chart     loaned ${_nf.format(chart.loanedAmount)}  '
+        'current ${_nf.format(chart.currentValue)}  '
+        '${ok ? '✓ matches' : '✗ DIFFERS'}');
+  } else {
+    print('  chart     NOT PRESENT (no owing logs or excluded)');
+  }
+}
+
+void main() {
+  test(
+    'fact-check loaner comparison against the real database',
+    () async {
+      final source = _resolveDbDir();
+      if (source == null) {
+        _printUsage();
+        markTestSkipped('No database found');
+        return;
+      }
+
+      // ignore: avoid_print
+      print('Using database folder: ${source.path}');
+
+      if (!await File('libisar.so').exists()) {
+        await Isar.initializeIsarCore(download: true);
+      } else {
+        await Isar.initializeIsarCore();
+      }
+
+      final tmp = await _copyDbToTemp(source);
+      late final Isar isar;
+      try {
+        isar = await Isar.open(
+          [LogSchema, ProductSchema, LoanerSchema, OwnerSchema, ExpenseSchema],
+          directory: tmp.path,
+          name: 'isarInstance',
+        );
+
+        final loaners = await isar.loaners.where().findAll();
+        final products = await isar.products.where().findAll();
+        final logs = await isar.logs
+            .filter()
+            .loanedEqualTo(true)
+            .sortByDateDesc()
+            .findAll();
+        final productMap = <int, Product>{};
+        for (final p in products) {
+          productMap[p.id] = p;
+        }
+
+        final eligible =
+            loaners.where((l) => (l.balance ?? 0) > 0).toList();
+        if (eligible.isEmpty) {
+          markTestSkipped('No loaners with a positive balance');
+          return;
+        }
+
+        final checks = <_LoanerCheck>[];
+        for (final loaner in eligible) {
+          final loanerLogs =
+              logs.where((log) => log.loanerID == loaner.ID).toList();
+          checks.add(_manualWalk(loaner, loanerLogs, productMap));
+        }
+
+        final chart = computeLoanerComparison( // ignore: invalid_use_of_visible_for_testing_member
+          loaners: eligible,
+          loanedLogs: logs,
+          productMap: productMap,
+        );
+        final chartByName = <String, LoanerComparison>{};
+        for (final c in chart) {
+          chartByName[c.name] = c;
+        }
+
+        // ignore: avoid_print
+        print('Checking ${checks.length} loaner(s)...');
+        final failures = <String>[];
+        for (final check in checks) {
+          final chartRes = chartByName[check.name];
+          _printReport(check, chartRes);
+
+          if (!_feq(check.loanedAmount, check.balance)) {
+            failures.add('${check.name}: loanedAmount '
+                '${_nf.format(check.loanedAmount)} != balance '
+                '${_nf.format(check.balance)}');
+          }
+          if (chartRes == null) {
+            failures.add(
+                '${check.name}: missing from chart output (no owing logs?)');
+          } else {
+            if (!_feq(chartRes.loanedAmount, check.loanedAmount)) {
+              failures.add('${check.name}: chart loanedAmount '
+                  '${_nf.format(chartRes.loanedAmount)} != manual '
+                  '${_nf.format(check.loanedAmount)}');
+            }
+            if (!_feq(chartRes.currentValue, check.currentValue)) {
+              failures.add('${check.name}: chart currentValue '
+                  '${_nf.format(chartRes.currentValue)} != manual '
+                  '${_nf.format(check.currentValue)}');
+            }
+          }
+        }
+
+        if (failures.isNotEmpty) {
+          fail('Fact-check FAILED:\n${failures.join('\n')}');
+        }
+        // ignore: avoid_print
+        print('RESULT: all ${checks.length} loaner(s) PASS ✓');
+      } finally {
+        await isar.close();
+        if (await tmp.exists()) {
+          await tmp.delete(recursive: true);
+        }
+      }
+    },
+    timeout: const Timeout(Duration(minutes: 10)),
+  );
+}

--- a/lib/core/db.dart
+++ b/lib/core/db.dart
@@ -2011,12 +2011,12 @@ class CgetLoanerComparison extends PooledJob<List<LoanerComparison>> {
       }
 
       final now = DateTime.now();
-      final monthAgo = DateTime(now.year, now.month - 1, now.day);
+      final windowStart = loanComparisonWindowStart(now);
       final loaners = await isar.loaners.where().findAll();
       final allLoanedLogs = await isar.logs
           .filter()
           .loanedEqualTo(true)
-          .dateBetween(monthAgo, now)
+          .dateBetween(windowStart, now)
           .findAll();
       final allProducts = await isar.products.where().findAll();
       final productMap = <int, Product>{};
@@ -2024,45 +2024,68 @@ class CgetLoanerComparison extends PooledJob<List<LoanerComparison>> {
         productMap[p.id] = p;
       }
 
-      final List<LoanerComparison> results = [];
-
-      for (final loaner in loaners) {
-        final loanerLogs =
-            allLoanedLogs.where((l) => l.loanerID == loaner.ID).toList();
-        if (loanerLogs.isEmpty) continue;
-
-        double loanedAmount = 0;
-        double currentValue = 0;
-
-        for (final log in loanerLogs) {
-          for (final ep in log.products) {
-            final count = ep.count ?? 0;
-            loanedAmount += (ep.sellPrice ?? 0) * count;
-
-            final buyPrice = (ep.productId != null && ep.productId! > 0)
-                ? (productMap[ep.productId]?.buyprice ?? (ep.buyPrice ?? 0))
-                : (ep.buyPrice ?? 0);
-            currentValue += buyPrice * count;
-          }
-        }
-
-        if (loanedAmount == 0 && currentValue == 0) continue;
-
-        results.add(LoanerComparison(
-          name: loaner.name ?? 'Unknown',
-          loanedAmount: loanedAmount,
-          currentValue: currentValue,
-        ));
-      }
-
-      results.sort((a, b) => b.loanedAmount.compareTo(a.loanedAmount));
-      return results;
+      return computeLoanerComparison(
+        loaners: loaners,
+        loanedLogs: allLoanedLogs,
+        productMap: productMap,
+      );
     } catch (e) {
       AppLogger.warning('Loaner comparison calculation failed',
           data: {'area': 'stats.loaner_comparison'});
       return [];
     }
   }
+}
+
+@visibleForTesting
+DateTime loanComparisonWindowStart(DateTime now) {
+  return now.subtract(const Duration(days: 45));
+}
+
+@visibleForTesting
+List<LoanerComparison> computeLoanerComparison({
+  required Iterable<Loaner> loaners,
+  required Iterable<Log> loanedLogs,
+  required Map<int, Product> productMap,
+}) {
+  final logsByLoaner = <int, List<Log>>{};
+  for (final log in loanedLogs) {
+    final id = log.loanerID;
+    if (id == null) continue;
+    logsByLoaner.putIfAbsent(id, () => []).add(log);
+  }
+
+  final results = <LoanerComparison>[];
+  for (final loaner in loaners) {
+    final loanerLogs = logsByLoaner[loaner.ID];
+    if (loanerLogs == null || loanerLogs.isEmpty) continue;
+
+    double loanedAmount = 0;
+    double currentValue = 0;
+
+    for (final log in loanerLogs) {
+      for (final ep in log.products) {
+        final count = ep.count ?? 0;
+        loanedAmount += (ep.sellPrice ?? 0) * count;
+
+        final buyPrice = (ep.productId != null && ep.productId! > 0)
+            ? (productMap[ep.productId]?.buyprice ?? (ep.buyPrice ?? 0))
+            : (ep.buyPrice ?? 0);
+        currentValue += buyPrice * count;
+      }
+    }
+
+    if (loanedAmount == 0 && currentValue == 0) continue;
+
+    results.add(LoanerComparison(
+      name: loaner.name ?? 'Unknown',
+      loanedAmount: loanedAmount,
+      currentValue: currentValue,
+    ));
+  }
+
+  results.sort((a, b) => b.loanedAmount.compareTo(a.loanedAmount));
+  return results;
 }
 
 double recalculateProfit(Iterable<Log> logs, Map<int, Product> productMap) {

--- a/lib/core/db.dart
+++ b/lib/core/db.dart
@@ -2105,6 +2105,7 @@ List<LoanerComparison> computeLoanerComparison({
 
       double logCurrentValue = 0;
       for (final ep in log.products) {
+        if (ep.hot == true) continue;
         final count = ep.count ?? 0;
         final buyPrice = (ep.productId != null && ep.productId! > 0)
             ? (productMap[ep.productId]?.buyprice ?? (ep.buyPrice ?? 0))

--- a/lib/core/db.dart
+++ b/lib/core/db.dart
@@ -2068,12 +2068,34 @@ DateTime? debtWindowStart({
   if (balance <= 0 || logsNewestFirst.isEmpty) return null;
   var remaining = balance;
   for (final log in logsNewestFirst) {
-    if (log.price <= 0) continue;
-    remaining -= log.price;
+    final value = logLoanedValue(log);
+    if (value <= 0) continue;
+    remaining -= value;
     if (remaining <= 0) return log.date;
   }
   return null;
 }
+
+/// The sell value of the hot products in a log. Hot products are not tracked
+/// in the product catalog (no reliable buy price), so this value is excluded
+/// from the loaner comparison chart but reconciles a loaner's balance with its
+/// tracked loaned amount.
+@visibleForTesting
+double hotSellValue(Log log) {
+  double value = 0;
+  for (final ep in log.products) {
+    if (ep.hot == true) {
+      value += (ep.sellPrice ?? 0) * (ep.count ?? 0);
+    }
+  }
+  return value;
+}
+
+/// The full sell value of a log, including hot products. A loaner's recorded
+/// balance is raised by this total on checkout, so the debt window must be
+/// sized with it even though the chart itself only shows tracked products.
+@visibleForTesting
+double logLoanedValue(Log log) => log.price + hotSellValue(log);
 
 @visibleForTesting
 List<LoanerComparison> computeLoanerComparison({
@@ -2100,8 +2122,8 @@ List<LoanerComparison> computeLoanerComparison({
 
     final sorted = [...loanerLogs]..sort((a, b) => b.date.compareTo(a.date));
     for (final log in sorted) {
-      final price = log.price;
-      if (price <= 0) continue;
+      final value = logLoanedValue(log);
+      if (value <= 0) continue;
 
       double logCurrentValue = 0;
       for (final ep in log.products) {
@@ -2113,15 +2135,15 @@ List<LoanerComparison> computeLoanerComparison({
         logCurrentValue += buyPrice * count;
       }
 
-      if (remaining <= price) {
-        final fraction = remaining / price;
-        loanedAmount += price * fraction;
+      if (remaining <= value) {
+        final fraction = remaining / value;
+        loanedAmount += log.price * fraction;
         currentValue += logCurrentValue * fraction;
         break;
       }
-      loanedAmount += price;
+      loanedAmount += log.price;
       currentValue += logCurrentValue;
-      remaining -= price;
+      remaining -= value;
     }
 
     if (loanedAmount == 0 && currentValue == 0) continue;

--- a/lib/core/db.dart
+++ b/lib/core/db.dart
@@ -2096,17 +2096,31 @@ List<LoanerComparison> computeLoanerComparison({
 
     double loanedAmount = 0;
     double currentValue = 0;
+    var remaining = loaner.balance ?? 0;
 
-    for (final log in loanerLogs) {
-      loanedAmount += log.price;
+    final sorted = [...loanerLogs]..sort((a, b) => b.date.compareTo(a.date));
+    for (final log in sorted) {
+      final price = log.price;
+      if (price <= 0) continue;
 
+      double logCurrentValue = 0;
       for (final ep in log.products) {
         final count = ep.count ?? 0;
         final buyPrice = (ep.productId != null && ep.productId! > 0)
             ? (productMap[ep.productId]?.buyprice ?? (ep.buyPrice ?? 0))
             : (ep.buyPrice ?? 0);
-        currentValue += buyPrice * count;
+        logCurrentValue += buyPrice * count;
       }
+
+      if (remaining <= price) {
+        final fraction = remaining / price;
+        loanedAmount += price * fraction;
+        currentValue += logCurrentValue * fraction;
+        break;
+      }
+      loanedAmount += price;
+      currentValue += logCurrentValue;
+      remaining -= price;
     }
 
     if (loanedAmount == 0 && currentValue == 0) continue;

--- a/lib/core/db.dart
+++ b/lib/core/db.dart
@@ -2010,22 +2010,21 @@ class CgetLoanerComparison extends PooledJob<List<LoanerComparison>> {
         isar = existing;
       }
 
-      final now = DateTime.now();
-      final windowStart = loanComparisonWindowStart(now);
       final loaners = await isar.loaners.where().findAll();
-      final allLoanedLogs = await isar.logs
-          .filter()
-          .loanedEqualTo(true)
-          .dateBetween(windowStart, now)
-          .findAll();
+      final eligible = loaners.where((l) => (l.balance ?? 0) > 0).toList();
       final allProducts = await isar.products.where().findAll();
       final productMap = <int, Product>{};
       for (final p in allProducts) {
         productMap[p.id] = p;
       }
 
+      final allLoanedLogs = <Log>[];
+      for (final loaner in eligible) {
+        allLoanedLogs.addAll(await _loadLoanerDebtTail(isar, loaner));
+      }
+
       return computeLoanerComparison(
-        loaners: loaners,
+        loaners: eligible,
         loanedLogs: allLoanedLogs,
         productMap: productMap,
       );
@@ -2037,9 +2036,43 @@ class CgetLoanerComparison extends PooledJob<List<LoanerComparison>> {
   }
 }
 
+Future<List<Log>> _loadLoanerDebtTail(Isar isar, Loaner loaner,
+    {int batch = 200}) async {
+  final balance = loaner.balance ?? 0;
+  final logs = <Log>[];
+  var offset = 0;
+  while (true) {
+    final chunk = await isar.logs
+        .filter()
+        .loanedEqualTo(true)
+        .loanerIDEqualTo(loaner.ID)
+        .sortByDateDesc()
+        .offset(offset)
+        .limit(batch)
+        .findAll();
+    if (chunk.isEmpty) break;
+    logs.addAll(chunk);
+    if (debtWindowStart(balance: balance, logsNewestFirst: logs) != null) {
+      break;
+    }
+    offset += batch;
+  }
+  return logs;
+}
+
 @visibleForTesting
-DateTime loanComparisonWindowStart(DateTime now) {
-  return now.subtract(const Duration(days: 45));
+DateTime? debtWindowStart({
+  required double balance,
+  required List<Log> logsNewestFirst,
+}) {
+  if (balance <= 0 || logsNewestFirst.isEmpty) return null;
+  var remaining = balance;
+  for (final log in logsNewestFirst) {
+    if (log.price <= 0) continue;
+    remaining -= log.price;
+    if (remaining <= 0) return log.date;
+  }
+  return null;
 }
 
 @visibleForTesting
@@ -2057,6 +2090,7 @@ List<LoanerComparison> computeLoanerComparison({
 
   final results = <LoanerComparison>[];
   for (final loaner in loaners) {
+    if ((loaner.balance ?? 0) <= 0) continue;
     final loanerLogs = logsByLoaner[loaner.ID];
     if (loanerLogs == null || loanerLogs.isEmpty) continue;
 
@@ -2064,10 +2098,10 @@ List<LoanerComparison> computeLoanerComparison({
     double currentValue = 0;
 
     for (final log in loanerLogs) {
+      loanedAmount += log.price;
+
       for (final ep in log.products) {
         final count = ep.count ?? 0;
-        loanedAmount += (ep.sellPrice ?? 0) * count;
-
         final buyPrice = (ep.productId != null && ep.productId! > 0)
             ? (productMap[ep.productId]?.buyprice ?? (ep.buyPrice ?? 0))
             : (ep.buyPrice ?? 0);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -108,6 +108,8 @@ class MyApp extends StatelessWidget {
           ],
           builder: (context, child) {
             WidgetsBinding.instance.addObserver(context.read<SalesProvider>());
+            context.read<SalesProvider>().onInventoryChanged =
+                context.read<Lists>().clearAllCache;
             var auth = context.watch<AuthAPI>();
             if (auth.status == AuthStatus.uninitialized) {
               return const Center(child: CircularProgressIndicator());

--- a/lib/pages/InsertPage.dart
+++ b/lib/pages/InsertPage.dart
@@ -413,7 +413,7 @@ class _InPageState extends State<InPage> {
                 // submit
                 Consumer<SalesProvider>(
                   builder: (context, sa, child) => IconButton(
-                    onPressed: () {
+                    onPressed: () async {
                       if (widget.index == -1) {
                         if (_validateFields()) {
                           final buyPrice = double.tryParse(widget.buyCon.text);
@@ -485,7 +485,7 @@ class _InPageState extends State<InPage> {
                             return;
                           }
                           Navigator.pop(context);
-                          li.db.insertProducts(products: temp);
+                          li.insertProducts(products: temp);
                         } else {
                           _showErrorDialog(context, 'ادخل قيم صحيحة');
                         }
@@ -589,7 +589,7 @@ class _InPageState extends State<InPage> {
                             _showErrorDialog(context, validationError);
                             return;
                           }
-                          sa.updateProduct(temp2);
+                          await sa.updateProduct(temp2);
                           Navigator.pop(context);
                         } else {
                           _showErrorDialog(context, 'ادخل قيم صحيحة');

--- a/lib/pages/InsertPage.dart
+++ b/lib/pages/InsertPage.dart
@@ -517,11 +517,37 @@ class _InPageState extends State<InPage> {
                               return;
                             }
                           }
-                          Emap emap = Emap()
-                            ..buyPrice = widget.buyPrice
-                            ..sellPrice = widget.sellPrice
-                            ..date = DateTime.now();
-                          widget.priceHistory.add(emap);
+                          final unitBuyPrice = widget.weightable
+                              ? buyPrice /
+                                  getWholeUnitNumber(widget.wholeUnitCon.text)
+                                      .toDouble()
+                              : buyPrice;
+                          final unitSellPrice = widget.weightable
+                              ? sellPrice /
+                                  getWholeUnitNumber(widget.wholeUnitCon.text)
+                                      .toDouble()
+                              : sellPrice;
+                          final now = DateTime.now();
+                          final todayIndex = widget.priceHistory.indexWhere(
+                            (e) {
+                              final d = e.date;
+                              return d != null &&
+                                  d.year == now.year &&
+                                  d.month == now.month &&
+                                  d.day == now.day;
+                            },
+                          );
+                          if (todayIndex != -1) {
+                            widget.priceHistory[todayIndex]
+                              ..buyPrice = unitBuyPrice
+                              ..sellPrice = unitSellPrice
+                              ..date = now;
+                          } else {
+                            widget.priceHistory.add(Emap()
+                              ..buyPrice = unitBuyPrice
+                              ..sellPrice = unitSellPrice
+                              ..date = now);
+                          }
                           Product temp2 = Product.named2(
                             id: widget.id!,
                             name: widget.nameCon.text,

--- a/lib/providers/list.dart
+++ b/lib/providers/list.dart
@@ -136,7 +136,7 @@ class Lists extends ChangeNotifier with LanSyncState {
     List<EmbeddedProduct> products = List.empty(growable: true);
     for (var product in log.products) {
       if (product.hot!) {
-        sum += product.buyPrice! * product.count!;
+        sum += product.sellPrice! * product.count!;
       } else {
         products.add(product);
       }
@@ -621,14 +621,14 @@ class Lists extends ChangeNotifier with LanSyncState {
             name: f.name,
             ownerName: null,
             barcode: null,
-            buyprice: f.buyPrice,
-            sellPrice: f.sellPrice,
-            count: f.count,
+            buyprice: f.buyPrice ?? 0,
+            sellPrice: f.sellPrice ?? 0,
+            count: f.count ?? 0,
             weightable: null,
             wholeUnit: null,
-            offer: null,
-            offerCount: null,
-            offerPrice: null,
+            offer: false,
+            offerCount: 0,
+            offerPrice: 0,
             priceHistory: [],
             endDate: null,
             hot: f.hot,
@@ -656,7 +656,7 @@ class Lists extends ChangeNotifier with LanSyncState {
     List<EmbeddedProduct> products = List.empty(growable: true);
     for (var product in log.products) {
       if (product.hot!) {
-        sum += product.buyPrice! * product.count!;
+        sum += product.sellPrice! * product.count!;
       } else {
         products.add(product);
       }

--- a/lib/providers/log_provider.dart
+++ b/lib/providers/log_provider.dart
@@ -25,7 +25,7 @@ class LogProvider extends ChangeNotifier {
     double sum = 0;
     for (var product in log.products) {
       if (product.hot!) {
-        sum += product.buyPrice! * product.count!;
+        sum += product.sellPrice! * product.count!;
       }
     }
     if (log.loaned) {

--- a/lib/providers/salesProvider.dart
+++ b/lib/providers/salesProvider.dart
@@ -312,10 +312,14 @@ class SalesProvider with ChangeNotifier, WidgetsBindingObserver {
     return await db.getAllProducts();
   }
 
-  void updateProduct(Product product) {
-    // product.priceHistory.add({DateTime.now(): product.buyprice});
-    db.isar!.writeTxn(() => db.isar!.products.put(product));
-    refreshProductsList();
+  Future<void> updateProduct(Product product) async {
+    await db.isar!.writeTxn(() => db.isar!.products.put(product));
+    await refreshProductsList();
+    onInventoryChanged?.call();
+  }
+
+  Future<void> insertProducts({required List<Product> products}) async {
+    await db.insertProducts(products: products);
     onInventoryChanged?.call();
   }
 

--- a/lib/providers/salesProvider.dart
+++ b/lib/providers/salesProvider.dart
@@ -17,6 +17,7 @@ class SalesProvider with ChangeNotifier, WidgetsBindingObserver {
   late SharedPreferences _pref;
   late DB db;
   List<Product>? _testProducts;
+  VoidCallback? onInventoryChanged;
   SalesProvider() {
     init();
   }
@@ -208,6 +209,7 @@ class SalesProvider with ChangeNotifier, WidgetsBindingObserver {
       await db.isar!.writeTxn(() async {
         await db.isar!.products.putAll(inboundList);
       });
+      onInventoryChanged?.call();
     }
   }
 
@@ -314,6 +316,7 @@ class SalesProvider with ChangeNotifier, WidgetsBindingObserver {
     // product.priceHistory.add({DateTime.now(): product.buyprice});
     db.isar!.writeTxn(() => db.isar!.products.put(product));
     refreshProductsList();
+    onInventoryChanged?.call();
   }
 
   Future<List<Product>> search(String keyWord, bool sales, bool barcode) {

--- a/lib/util/charts.dart
+++ b/lib/util/charts.dart
@@ -144,6 +144,10 @@ class _LoanerChartState extends State<LoanerChart>
             );
           }
           final chartHeight = max(300.0, data.length * 50.0);
+          final maxValue = data.fold<double>(
+            0,
+            (m, d) => max(m, max(d.loanedAmount, d.currentValue)),
+          );
           return SizedBox(
             height: chartHeight,
             child: ExcludeSemantics(
@@ -151,31 +155,33 @@ class _LoanerChartState extends State<LoanerChart>
               child: RepaintBoundary(
                 child: SfCartesianChart(
                   title: ChartTitle(
-                    text: 'مقارنة القروض لهذا الشهر',
+                    text: 'مقارنة القروض (آخر ٤٥ يوم)',
                     alignment: ChartAlignment.near,
                   ),
-                  primaryXAxis: CategoryAxis(
-                    labelRotation: 45,
-                  ),
+                  primaryXAxis: CategoryAxis(),
                   primaryYAxis: NumericAxis(
                     numberFormat: NumberFormat.compact(),
                     isVisible: true,
+                    maximum: maxValue <= 0 ? 1 : maxValue * 1.25,
                   ),
                   tooltipBehavior: TooltipBehavior(enable: _tooltipReady),
                   series: <CartesianSeries>[
-                    ColumnSeries<LoanerComparison, String>(
+                    BarSeries<LoanerComparison, String>(
                       name: 'سعر البيع الأصلي',
                       animationDuration: 0,
                       color: Colors.brown,
                       dataSource: data,
                       xValueMapper: (LoanerComparison d, _) => d.name,
                       yValueMapper: (LoanerComparison d, _) => d.loanedAmount,
+                      dataLabelMapper: (LoanerComparison d, _) =>
+                          '${NumberFormat.simpleCurrency().format(d.loanedAmount)}\n'
+                          '${_formatGainLoss(d.loanedAmount - d.currentValue)}',
                       dataLabelSettings: const DataLabelSettings(
                         isVisible: true,
-                        labelAlignment: ChartDataLabelAlignment.top,
+                        labelAlignment: ChartDataLabelAlignment.outer,
                       ),
                     ),
-                    ColumnSeries<LoanerComparison, String>(
+                    BarSeries<LoanerComparison, String>(
                       name: 'سعر الشراء الحالي',
                       animationDuration: 0,
                       color: Colors.red[400],
@@ -184,7 +190,7 @@ class _LoanerChartState extends State<LoanerChart>
                       yValueMapper: (LoanerComparison d, _) => d.currentValue,
                       dataLabelSettings: const DataLabelSettings(
                         isVisible: true,
-                        labelAlignment: ChartDataLabelAlignment.top,
+                        labelAlignment: ChartDataLabelAlignment.outer,
                       ),
                     ),
                   ],
@@ -201,6 +207,14 @@ class _LoanerChartState extends State<LoanerChart>
         }
       },
     );
+  }
+
+  String _formatGainLoss(double diff) {
+    final formatted = NumberFormat.simpleCurrency().format(diff.abs());
+    if (diff >= 0) {
+      return '▲ ربح $formatted';
+    }
+    return '▼ خسارة $formatted';
   }
 
   @override

--- a/lib/util/charts.dart
+++ b/lib/util/charts.dart
@@ -217,13 +217,6 @@ class _LoanerChartState extends State<LoanerChart>
                       dataSource: data,
                       xValueMapper: (LoanerComparison d, _) => d.name,
                       yValueMapper: (LoanerComparison d, _) => d.loanedAmount,
-                      dataLabelMapper: (LoanerComparison d, _) =>
-                          '${NumberFormat.simpleCurrency().format(d.loanedAmount)}\n'
-                          '${_formatGainLoss(d.loanedAmount - d.currentValue)}',
-                      dataLabelSettings: const DataLabelSettings(
-                        isVisible: true,
-                        labelAlignment: ChartDataLabelAlignment.outer,
-                      ),
                     ),
                     BarSeries<LoanerComparison, String>(
                       name: 'سعر الشراء الحالي',
@@ -232,10 +225,6 @@ class _LoanerChartState extends State<LoanerChart>
                       dataSource: data,
                       xValueMapper: (LoanerComparison d, _) => d.name,
                       yValueMapper: (LoanerComparison d, _) => d.currentValue,
-                      dataLabelSettings: const DataLabelSettings(
-                        isVisible: true,
-                        labelAlignment: ChartDataLabelAlignment.outer,
-                      ),
                     ),
                   ],
                 ),

--- a/lib/util/charts.dart
+++ b/lib/util/charts.dart
@@ -144,9 +144,9 @@ class _LoanerChartState extends State<LoanerChart>
             );
           }
           final chartHeight = max(300.0, data.length * 50.0);
-          final maxValue = data.fold<double>(
+          final maxAbs = data.fold<double>(
             0,
-            (m, d) => max(m, max(d.loanedAmount, d.currentValue)),
+            (m, d) => max(m, (d.loanedAmount - d.currentValue).abs()),
           );
           return SizedBox(
             height: chartHeight,
@@ -155,14 +155,15 @@ class _LoanerChartState extends State<LoanerChart>
               child: RepaintBoundary(
                 child: SfCartesianChart(
                   title: ChartTitle(
-                    text: 'مقارنة القروض المستحقة',
+                    text: 'ربح أو خسارة القروض',
                     alignment: ChartAlignment.near,
                   ),
                   primaryXAxis: CategoryAxis(),
                   primaryYAxis: NumericAxis(
                     numberFormat: NumberFormat.compact(),
                     isVisible: true,
-                    maximum: maxValue <= 0 ? 1 : maxValue * 1.25,
+                    minimum: -(maxAbs <= 0 ? 1.0 : maxAbs * 1.15),
+                    maximum: maxAbs <= 0 ? 1.0 : maxAbs * 1.15,
                   ),
                   tooltipBehavior: TooltipBehavior(
                     enable: _tooltipReady,
@@ -210,21 +211,18 @@ class _LoanerChartState extends State<LoanerChart>
                     },
                   ),
                   series: <CartesianSeries>[
-                    BarSeries<LoanerComparison, String>(
-                      name: 'سعر البيع الأصلي',
+                    ColumnSeries<LoanerComparison, String>(
+                      name: 'الربح أو الخسارة',
                       animationDuration: 0,
-                      color: Colors.brown,
+                      width: 0.5,
                       dataSource: data,
                       xValueMapper: (LoanerComparison d, _) => d.name,
-                      yValueMapper: (LoanerComparison d, _) => d.loanedAmount,
-                    ),
-                    BarSeries<LoanerComparison, String>(
-                      name: 'سعر الشراء الحالي',
-                      animationDuration: 0,
-                      color: Colors.red[400],
-                      dataSource: data,
-                      xValueMapper: (LoanerComparison d, _) => d.name,
-                      yValueMapper: (LoanerComparison d, _) => d.currentValue,
+                      yValueMapper: (LoanerComparison d, _) =>
+                          d.loanedAmount - d.currentValue,
+                      pointColorMapper: (LoanerComparison d, _) =>
+                          (d.loanedAmount - d.currentValue) >= 0
+                              ? Colors.green
+                              : Colors.red,
                     ),
                   ],
                 ),

--- a/lib/util/charts.dart
+++ b/lib/util/charts.dart
@@ -155,7 +155,7 @@ class _LoanerChartState extends State<LoanerChart>
               child: RepaintBoundary(
                 child: SfCartesianChart(
                   title: ChartTitle(
-                    text: 'مقارنة القروض (آخر ٤٥ يوم)',
+                    text: 'مقارنة القروض المستحقة',
                     alignment: ChartAlignment.near,
                   ),
                   primaryXAxis: CategoryAxis(),

--- a/lib/util/charts.dart
+++ b/lib/util/charts.dart
@@ -164,7 +164,51 @@ class _LoanerChartState extends State<LoanerChart>
                     isVisible: true,
                     maximum: maxValue <= 0 ? 1 : maxValue * 1.25,
                   ),
-                  tooltipBehavior: TooltipBehavior(enable: _tooltipReady),
+                  tooltipBehavior: TooltipBehavior(
+                    enable: _tooltipReady,
+                    builder: (dynamic data, dynamic point, dynamic series,
+                        int pointIndex, int seriesIndex) {
+                      final d = data as LoanerComparison;
+                      final diff = d.loanedAmount - d.currentValue;
+                      return Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color: Colors.brown[700],
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              d.name,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            Text(
+                              'بيع: ${NumberFormat.simpleCurrency().format(d.loanedAmount)}',
+                              style: const TextStyle(color: Colors.white70),
+                            ),
+                            Text(
+                              'شراء: ${NumberFormat.simpleCurrency().format(d.currentValue)}',
+                              style: const TextStyle(color: Colors.white70),
+                            ),
+                            Text(
+                              _formatGainLoss(diff),
+                              style: TextStyle(
+                                color: diff >= 0
+                                    ? Colors.greenAccent
+                                    : Colors.redAccent,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
                   series: <CartesianSeries>[
                     BarSeries<LoanerComparison, String>(
                       name: 'سعر البيع الأصلي',

--- a/lib/util/receipt.dart
+++ b/lib/util/receipt.dart
@@ -192,6 +192,7 @@ class _ReceiptState extends State<Receipt> {
                                           return;
                                         }
                                         sa.sellList = products;
+                                        sa.refresh();
                                         li.editing = true;
                                         li.logID = widget.log.date;
                                         if (outerContext.mounted) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.4.17+1
+version: 2.4.18+1
 
 environment:
   sdk: ">=3.0.5 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.4.16+1
+version: 2.4.17+1
 
 environment:
   sdk: ">=3.0.5 <4.0.0"

--- a/test/integration/real_database_test.dart
+++ b/test/integration/real_database_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:dukkan/providers/loan_provider.dart';
 import 'package:dukkan/providers/list.dart';
+import 'package:dukkan/providers/salesProvider.dart';
 import 'package:dukkan/util/models/Expense.dart';
 import 'package:dukkan/util/models/Log.dart';
 import 'package:dukkan/util/models/Loaner.dart';
@@ -12,6 +13,7 @@ import 'package:dukkan/util/models/Owner.dart';
 import 'package:dukkan/util/models/Product.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:isar_community/isar.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/fixtures.dart';
 import '../helpers/test_db.dart';
@@ -358,6 +360,70 @@ void main() {
 
       final loaner = await handle.db.isar!.loaners.get(loanerId);
       expect(loaner!.balance, 220);
+    });
+  });
+
+  group('Inventory product update refresh', () {
+    late SharedPreferences prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+    });
+
+    test('updateProduct persists before notifying inventory listeners',
+        () async {
+      final product = await insertProduct(name: 'Sugar', count: 10);
+      final sa = SalesProvider.forTesting(db: handle.db, pref: prefs);
+
+      var notified = false;
+      sa.onInventoryChanged = () => notified = true;
+
+      final updated = Product.named2(
+        id: product.id,
+        name: 'Sugar',
+        ownerName: product.ownerName!,
+        barcode: product.barcode ?? '',
+        buyprice: 7,
+        sellPrice: 12,
+        count: 5,
+        weightable: product.weightable ?? false,
+        wholeUnit: product.wholeUnit ?? '',
+        offer: product.offer ?? false,
+        offerCount: product.offerCount ?? 0,
+        offerPrice: product.offerPrice ?? 0,
+        priceHistory: product.priceHistory,
+        endDate: product.endDate ?? DateTime.now(),
+        hot: false,
+      );
+
+      await sa.updateProduct(updated);
+
+      expect(notified, isTrue);
+      final persisted =
+          (await handle.db.isar!.products.get(product.id))!;
+      expect(persisted.buyprice, 7);
+      expect(persisted.sellPrice, 12);
+      expect(persisted.count, 5);
+    });
+
+    test('insertProducts notifies inventory listeners after persisting',
+        () async {
+      final sa = SalesProvider.forTesting(db: handle.db, pref: prefs);
+
+      var notified = false;
+      sa.onInventoryChanged = () => notified = true;
+
+      final product =
+          productFixture(name: 'Rice', count: 3, buyPrice: 5, sellPrice: 8);
+      await sa.insertProducts(products: [product]);
+
+      expect(notified, isTrue);
+      final persisted = await handle.db.isar!.products
+          .where()
+          .nameEqualTo('Rice')
+          .findFirst();
+      expect(persisted, isNotNull);
     });
   });
 }

--- a/test/integration/real_database_test.dart
+++ b/test/integration/real_database_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:io';
 
 import 'package:dukkan/providers/loan_provider.dart';
+import 'package:dukkan/providers/list.dart';
 import 'package:dukkan/util/models/Expense.dart';
 import 'package:dukkan/util/models/Log.dart';
 import 'package:dukkan/util/models/Loaner.dart';
@@ -293,6 +294,70 @@ void main() {
       await handle.db.windows();
       final restored = await handle.db.isar!.products.get(product.id);
       expect(restored!.count, 7);
+    });
+  });
+
+  group('Real receipt edit tests', () {
+    test('hot products restored for editing carry non-null offer fields',
+        () async {
+      final lists = Lists.forTesting(handle.db);
+      final ep = EmbeddedProduct()
+        ..productId = 1
+        ..name = 'Hot'
+        ..buyPrice = 100
+        ..sellPrice = 200
+        ..count = 1
+        ..hot = true;
+
+      final products = lists.embeddedToProduct([ep]);
+
+      final hot = products.single;
+      expect(hot!.hot, isTrue);
+      expect(hot.offer, isNotNull);
+      expect(hot.offerCount, isNotNull);
+      expect(hot.offerPrice, isNotNull);
+      expect(hot.sellPrice, 200);
+    });
+
+    test('edit receipt subtracts hot sell value (not buy value) from balance',
+        () async {
+      final product = await insertProduct(name: 'Sugar', count: 10);
+      final loanerId =
+          await handle.db.insertLoaner(loanerFixture(amount: 500));
+      final normal = EmbeddedProduct()
+        ..productId = product.id
+        ..name = product.name
+        ..buyPrice = product.buyprice
+        ..sellPrice = product.sellPrice
+        ..count = 2
+        ..hot = false;
+      final hot = EmbeddedProduct()
+        ..productId = 0
+        ..name = 'Hot'
+        ..buyPrice = 100
+        ..sellPrice = 200
+        ..count = 1
+        ..hot = true;
+      final log = Log.named2(
+        price: 80,
+        profit: 0,
+        date: DateTime.now(),
+        products: [normal, hot],
+        discount: 0,
+        loaned: true,
+        loanerID: loanerId,
+        expense: false,
+        expenseId: null,
+      );
+      await handle.db.isar!.writeTxn(() async {
+        await handle.db.isar!.logs.put(log);
+      });
+
+      final lists = Lists.forTesting(handle.db);
+      await lists.editReceipt(log.date, log);
+
+      final loaner = await handle.db.isar!.loaners.get(loanerId);
+      expect(loaner!.balance, 220);
     });
   });
 }

--- a/test/unit/loaner_comparison_test.dart
+++ b/test/unit/loaner_comparison_test.dart
@@ -231,7 +231,7 @@ void main() {
     test('uses the log price for loaned amount and buy price for current value',
         () {
       final product = _makeProduct(id: 1, buyPrice: 10);
-      final loaner = _makeLoaner(id: 5, name: 'Ahmed');
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 150);
       final log = _makeLoanedLog(
         loanerId: 5,
         date: DateTime(2026, 5, 10),
@@ -257,7 +257,7 @@ void main() {
 
     test('loaner balance is deducted from the log price', () {
       final product = _makeProduct(id: 1, buyPrice: 10);
-      final loaner = _makeLoaner(id: 5, name: 'Ahmed');
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 50);
       final log = _makeLoanedLog(
         loanerId: 5,
         date: DateTime(2026, 5, 10),
@@ -279,7 +279,7 @@ void main() {
     });
 
     test('missing product in map falls back to receipt buy price snapshot', () {
-      final loaner = _makeLoaner(id: 5, name: 'Ahmed');
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 160);
       final log = _makeLoanedLog(
         loanerId: 5,
         date: DateTime(2026, 5, 10),
@@ -296,6 +296,76 @@ void main() {
 
       expect(result.first.loanedAmount, 40 * 4);
       expect(result.first.currentValue, 15 * 4);
+    });
+
+    test('scales the boundary log to the outstanding balance', () {
+      final product = _makeProduct(id: 1, buyPrice: 10);
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 100);
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 5),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [log],
+        productMap: {1: product},
+      );
+
+      expect(result.first.loanedAmount, 100);
+      expect(result.first.currentValue, 25);
+    });
+
+    test('counts newer logs fully and scales the boundary log', () {
+      final product = _makeProduct(id: 1, buyPrice: 10);
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 100);
+      final newer = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 1),
+        ],
+      );
+      final older = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 4, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 50, count: 6),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [newer, older],
+        productMap: {1: product},
+      );
+
+      expect(result.first.loanedAmount, 100);
+      expect(result.first.currentValue, 22);
+    });
+
+    test('boundary reached exactly uses the full log', () {
+      final product = _makeProduct(id: 1, buyPrice: 10);
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 200);
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 5),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [log],
+        productMap: {1: product},
+      );
+
+      expect(result.first.loanedAmount, 200);
+      expect(result.first.currentValue, 50);
     });
 
     test('loaner with no loaned logs is skipped', () {
@@ -328,8 +398,8 @@ void main() {
     });
 
     test('results are sorted by loaned amount descending', () {
-      final loanerA = _makeLoaner(id: 1, name: 'A');
-      final loanerB = _makeLoaner(id: 2, name: 'B');
+      final loanerA = _makeLoaner(id: 1, name: 'A', balance: 100);
+      final loanerB = _makeLoaner(id: 2, name: 'B', balance: 20);
       final logA = _makeLoanedLog(
         loanerId: 1,
         date: DateTime(2026, 5, 10),

--- a/test/unit/loaner_comparison_test.dart
+++ b/test/unit/loaner_comparison_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dukkan/core/db.dart'
-    show computeLoanerComparison, debtWindowStart;
+    show computeLoanerComparison, debtWindowStart, hotSellValue, logLoanedValue;
 import 'package:dukkan/util/models/Loaner.dart';
 import 'package:dukkan/util/models/Log.dart';
 import 'package:dukkan/util/models/Product.dart';
@@ -69,7 +69,8 @@ Log _makeLoanedLog({
 }) {
   final price = products.fold<double>(
         0,
-        (sum, ep) => sum + ((ep.sellPrice ?? 0) * (ep.count ?? 0)),
+        (sum, ep) => sum +
+            ((ep.hot == true ? 0 : ep.sellPrice ?? 0) * (ep.count ?? 0)),
       ) -
       discount;
   return Log.named2(
@@ -221,6 +222,75 @@ void main() {
         newest.date,
       );
     });
+
+    test('counts hot sell value toward the balance coverage', () {
+      final newest = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 1),
+          _makeEmbedded(
+            productId: 2,
+            buyPrice: 100,
+            sellPrice: 200,
+            count: 1,
+            hot: true,
+          ),
+        ],
+      );
+      final older = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 4, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+        ],
+      );
+      expect(
+        debtWindowStart(balance: 100, logsNewestFirst: [newest, older]),
+        newest.date,
+      );
+    });
+
+    test('boundary is reached inside the hot share of a log', () {
+      final newest = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 1),
+          _makeEmbedded(
+            productId: 2,
+            buyPrice: 100,
+            sellPrice: 200,
+            count: 1,
+            hot: true,
+          ),
+        ],
+      );
+      expect(
+        debtWindowStart(balance: 100, logsNewestFirst: [newest]),
+        newest.date,
+      );
+    });
+
+    test('hot-only log (tracked price zero) still covers the balance', () {
+      final newest = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(
+            productId: 2,
+            buyPrice: 100,
+            sellPrice: 200,
+            count: 1,
+            hot: true,
+          ),
+        ],
+      );
+      expect(
+        debtWindowStart(balance: 200, logsNewestFirst: [newest]),
+        newest.date,
+      );
+    });
   });
 
   group('computeLoanerComparison', () {
@@ -369,7 +439,7 @@ void main() {
       expect(result.first.currentValue, 50);
     });
 
-    test('skips hot products from the current value only', () {
+    test('excludes hot products from the comparison but tracks their value', () {
       final product = _makeProduct(id: 1, buyPrice: 10);
       final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 260);
       final log = _makeLoanedLog(
@@ -393,8 +463,135 @@ void main() {
         productMap: {1: product, 2: _makeProduct(id: 2, buyPrice: 100)},
       );
 
-      expect(result.first.loanedAmount, (30 * 2) + (200 * 1));
+      expect(result.first.loanedAmount, 30 * 2);
       expect(result.first.currentValue, 20);
+      expect(hotSellValue(log), 200);
+    });
+
+    test('hot value reconciles tracked debt with the balance', () {
+      final product = _makeProduct(id: 1, buyPrice: 10);
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 260);
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+          _makeEmbedded(
+            productId: 2,
+            buyPrice: 100,
+            sellPrice: 200,
+            count: 1,
+            hot: true,
+          ),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [log],
+        productMap: {1: product, 2: _makeProduct(id: 2, buyPrice: 100)},
+      );
+
+      final tracked = result.first.loanedAmount;
+      expect(tracked + hotSellValue(log), loaner.balance);
+    });
+
+    test('hot products size the window and reconcile tracked debt', () {
+      final product = _makeProduct(id: 1, buyPrice: 10);
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 100);
+      final newer = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 1),
+          _makeEmbedded(
+            productId: 2,
+            buyPrice: 100,
+            sellPrice: 200,
+            count: 1,
+            hot: true,
+          ),
+        ],
+      );
+      final older = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 4, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [newer, older],
+        productMap: {1: product, 2: _makeProduct(id: 2, buyPrice: 100)},
+      );
+
+      final fraction = 100 / (40 + 200);
+      expect(result.first.loanedAmount, closeTo(40 * fraction, 0.001));
+      expect(result.first.currentValue, closeTo(10 * fraction, 0.001));
+      expect(
+        result.first.loanedAmount + (200 * fraction),
+        closeTo(loaner.balance!, 0.001),
+      );
+    });
+
+    test('hot-only log consumes the window but contributes nothing', () {
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 100);
+      final hotOnly = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(
+            productId: 2,
+            buyPrice: 100,
+            sellPrice: 200,
+            count: 1,
+            hot: true,
+          ),
+        ],
+      );
+      final older = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 4, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [hotOnly, older],
+        productMap: {1: _makeProduct(id: 1, buyPrice: 10)},
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('hot-only log (price zero) is skipped by the chart', () {
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 200);
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(
+            productId: 2,
+            buyPrice: 100,
+            sellPrice: 200,
+            count: 1,
+            hot: true,
+          ),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [log],
+        productMap: {},
+      );
+
+      expect(result, isEmpty);
+      expect(hotSellValue(log), 200);
     });
 
     test('loaner with no loaned logs is skipped', () {
@@ -451,6 +648,85 @@ void main() {
       );
 
       expect(result.map((e) => e.name).toList(), ['A', 'B']);
+    });
+  });
+
+  group('hotSellValue', () {
+    test('returns zero for logs without hot products', () {
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+        ],
+      );
+      expect(hotSellValue(log), 0);
+    });
+
+    test('sums sell value of hot products only', () {
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+          _makeEmbedded(
+            productId: 2,
+            buyPrice: 100,
+            sellPrice: 200,
+            count: 3,
+            hot: true,
+          ),
+        ],
+      );
+      expect(hotSellValue(log), 600);
+    });
+
+    test('applies the offer-adjusted sell price snapshot to hot items', () {
+      final ep = _makeEmbedded(
+        productId: 2,
+        buyPrice: 100,
+        sellPrice: 200,
+        count: 1,
+        hot: true,
+      )..sellPrice = 150;
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [ep],
+      );
+      expect(hotSellValue(log), 150);
+    });
+  });
+
+  group('logLoanedValue', () {
+    test('is the tracked price for logs without hot products', () {
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+        ],
+        discount: 10,
+      );
+      expect(logLoanedValue(log), log.price);
+    });
+
+    test('adds the hot sell value to the tracked price', () {
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+          _makeEmbedded(
+            productId: 2,
+            buyPrice: 100,
+            sellPrice: 200,
+            count: 3,
+            hot: true,
+          ),
+        ],
+      );
+      expect(logLoanedValue(log), (30 * 2) + (200 * 3));
     });
   });
 }

--- a/test/unit/loaner_comparison_test.dart
+++ b/test/unit/loaner_comparison_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dukkan/core/db.dart'
+    show computeLoanerComparison, loanComparisonWindowStart;
+import 'package:dukkan/util/models/Loaner.dart';
+import 'package:dukkan/util/models/Log.dart';
+import 'package:dukkan/util/models/Product.dart';
+
+Loaner _makeLoaner({
+  required int id,
+  required String name,
+}) {
+  return Loaner.named(
+    name: name,
+    ID: id,
+    phoneNumber: '0',
+    location: '',
+    lastPaymentTemp: 0,
+    lastPaymentDate: null,
+    balance: 0,
+  );
+}
+
+Product _makeProduct({
+  required int id,
+  required double buyPrice,
+}) {
+  return Product.named2(
+    id: id,
+    name: 'Test',
+    ownerName: 'Owner',
+    barcode: '123',
+    buyprice: buyPrice,
+    sellPrice: 100,
+    count: 10,
+    weightable: false,
+    wholeUnit: '',
+    offer: false,
+    offerCount: 0,
+    offerPrice: 0,
+    priceHistory: [],
+    endDate: DateTime.now().add(const Duration(days: 30)),
+    hot: false,
+  );
+}
+
+EmbeddedProduct _makeEmbedded({
+  required int? productId,
+  required double buyPrice,
+  required double sellPrice,
+  required int count,
+}) {
+  final ep = EmbeddedProduct();
+  ep.productId = productId;
+  ep.name = 'Test';
+  ep.buyPrice = buyPrice;
+  ep.sellPrice = sellPrice;
+  ep.count = count;
+  ep.hot = false;
+  return ep;
+}
+
+Log _makeLoanedLog({
+  required int loanerId,
+  required List<EmbeddedProduct> products,
+  required DateTime date,
+}) {
+  return Log.named2(
+    price: 0,
+    profit: 0,
+    date: date,
+    products: products,
+    discount: 0,
+    loaned: true,
+    loanerID: loanerId,
+    expense: false,
+    expenseId: null,
+  );
+}
+
+void main() {
+  group('loanComparisonWindowStart', () {
+    test('is exactly 45 days before the given date', () {
+      final now = DateTime(2026, 5, 31);
+      expect(loanComparisonWindowStart(now), DateTime(2026, 4, 16));
+    });
+
+    test('does not roll over on month boundaries', () {
+      final now = DateTime(2026, 5, 31);
+      final start = loanComparisonWindowStart(now);
+      final log40DaysBack = now.subtract(const Duration(days: 40));
+      final log50DaysBack = now.subtract(const Duration(days: 50));
+      expect(start.isAfter(log50DaysBack), isTrue);
+      expect(start.isBefore(log40DaysBack), isTrue);
+    });
+  });
+
+  group('computeLoanerComparison', () {
+    test('empty inputs return empty list', () {
+      expect(computeLoanerComparison(loaners: [], loanedLogs: [], productMap: {}),
+          isEmpty);
+    });
+
+    test('aggregates loaned amount at sell price and current value at buy price',
+        () {
+      final product = _makeProduct(id: 1, buyPrice: 10);
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed');
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(
+              productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+          _makeEmbedded(
+              productId: 1, buyPrice: 10, sellPrice: 30, count: 3),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [log],
+        productMap: {1: product},
+      );
+
+      expect(result, hasLength(1));
+      expect(result.first.name, 'Ahmed');
+      expect(result.first.loanedAmount, (30 * 2) + (30 * 3));
+      expect(result.first.currentValue, (10 * 2) + (10 * 3));
+    });
+
+    test('missing product in map falls back to receipt buy price snapshot', () {
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed');
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 999, buyPrice: 15, sellPrice: 40, count: 4),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [log],
+        productMap: {},
+      );
+
+      expect(result.first.loanedAmount, 40 * 4);
+      expect(result.first.currentValue, 15 * 4);
+    });
+
+    test('loaner with no loaned logs is skipped', () {
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed');
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [],
+        productMap: {},
+      );
+      expect(result, isEmpty);
+    });
+
+    test('results are sorted by loaned amount descending', () {
+      final loanerA = _makeLoaner(id: 1, name: 'A');
+      final loanerB = _makeLoaner(id: 2, name: 'B');
+      final logA = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 999, buyPrice: 10, sellPrice: 20, count: 5),
+        ],
+      );
+      final logB = _makeLoanedLog(
+        loanerId: 2,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 999, buyPrice: 10, sellPrice: 20, count: 1),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loanerA, loanerB],
+        loanedLogs: [logA, logB],
+        productMap: {},
+      );
+
+      expect(result.map((e) => e.name).toList(), ['A', 'B']);
+    });
+  });
+}

--- a/test/unit/loaner_comparison_test.dart
+++ b/test/unit/loaner_comparison_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dukkan/core/db.dart'
-    show computeLoanerComparison, loanComparisonWindowStart;
+    show computeLoanerComparison, debtWindowStart;
 import 'package:dukkan/util/models/Loaner.dart';
 import 'package:dukkan/util/models/Log.dart';
 import 'package:dukkan/util/models/Product.dart';
@@ -8,6 +8,7 @@ import 'package:dukkan/util/models/Product.dart';
 Loaner _makeLoaner({
   required int id,
   required String name,
+  double balance = 100,
 }) {
   return Loaner.named(
     name: name,
@@ -16,7 +17,7 @@ Loaner _makeLoaner({
     location: '',
     lastPaymentTemp: 0,
     lastPaymentDate: null,
-    balance: 0,
+    balance: balance,
   );
 }
 
@@ -63,13 +64,19 @@ Log _makeLoanedLog({
   required int loanerId,
   required List<EmbeddedProduct> products,
   required DateTime date,
+  double discount = 0,
 }) {
+  final price = products.fold<double>(
+        0,
+        (sum, ep) => sum + ((ep.sellPrice ?? 0) * (ep.count ?? 0)),
+      ) -
+      discount;
   return Log.named2(
-    price: 0,
+    price: price,
     profit: 0,
     date: date,
     products: products,
-    discount: 0,
+    discount: discount,
     loaned: true,
     loanerID: loanerId,
     expense: false,
@@ -78,19 +85,140 @@ Log _makeLoanedLog({
 }
 
 void main() {
-  group('loanComparisonWindowStart', () {
-    test('is exactly 45 days before the given date', () {
-      final now = DateTime(2026, 5, 31);
-      expect(loanComparisonWindowStart(now), DateTime(2026, 4, 16));
+  group('debtWindowStart', () {
+    test('returns null for empty logs', () {
+      expect(debtWindowStart(balance: 100, logsNewestFirst: []), isNull);
     });
 
-    test('does not roll over on month boundaries', () {
-      final now = DateTime(2026, 5, 31);
-      final start = loanComparisonWindowStart(now);
-      final log40DaysBack = now.subtract(const Duration(days: 40));
-      final log50DaysBack = now.subtract(const Duration(days: 50));
-      expect(start.isAfter(log50DaysBack), isTrue);
-      expect(start.isBefore(log40DaysBack), isTrue);
+    test('returns null when balance is not positive', () {
+      final log = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+        ],
+      );
+      expect(debtWindowStart(balance: 0, logsNewestFirst: [log]), isNull);
+    });
+
+    test('returns null when logs do not cover the balance', () {
+      final newer = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+        ],
+      );
+      final older = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 4, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 1),
+        ],
+      );
+      expect(
+        debtWindowStart(balance: 250, logsNewestFirst: [newer, older]),
+        isNull,
+      );
+    });
+
+    test('returns the newest log date when it alone covers the balance', () {
+      final newest = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 2),
+        ],
+      );
+      final older = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 4, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+        ],
+      );
+      expect(
+        debtWindowStart(balance: 50, logsNewestFirst: [newest, older]),
+        newest.date,
+      );
+    });
+
+    test('returns the oldest log date when coverage spans multiple logs', () {
+      final newer = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 2),
+        ],
+      );
+      final older = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 4, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 3),
+        ],
+      );
+      expect(
+        debtWindowStart(balance: 150, logsNewestFirst: [newer, older]),
+        older.date,
+      );
+    });
+
+    test('returns the boundary log when the balance is covered exactly', () {
+      final newest = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 2),
+        ],
+      );
+      final older = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 4, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+        ],
+      );
+      expect(
+        debtWindowStart(balance: 80, logsNewestFirst: [newest, older]),
+        newest.date,
+      );
+    });
+
+    test('skips logs with zero price', () {
+      final zero = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 20),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 0, count: 2),
+        ],
+      );
+      final newest = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 2),
+        ],
+      );
+      expect(
+        debtWindowStart(balance: 50, logsNewestFirst: [zero, newest]),
+        newest.date,
+      );
+    });
+
+    test('discount is included in the log price used for coverage', () {
+      final newest = _makeLoanedLog(
+        loanerId: 1,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 40, count: 2),
+        ],
+        discount: 30,
+      );
+      expect(
+        debtWindowStart(balance: 50, logsNewestFirst: [newest]),
+        newest.date,
+      );
     });
   });
 
@@ -100,7 +228,7 @@ void main() {
           isEmpty);
     });
 
-    test('aggregates loaned amount at sell price and current value at buy price',
+    test('uses the log price for loaned amount and buy price for current value',
         () {
       final product = _makeProduct(id: 1, buyPrice: 10);
       final loaner = _makeLoaner(id: 5, name: 'Ahmed');
@@ -125,6 +253,29 @@ void main() {
       expect(result.first.name, 'Ahmed');
       expect(result.first.loanedAmount, (30 * 2) + (30 * 3));
       expect(result.first.currentValue, (10 * 2) + (10 * 3));
+    });
+
+    test('loaner balance is deducted from the log price', () {
+      final product = _makeProduct(id: 1, buyPrice: 10);
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed');
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        discount: 10,
+        products: [
+          _makeEmbedded(
+              productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [log],
+        productMap: {1: product},
+      );
+
+      expect(result.first.loanedAmount, 50);
+      expect(result.first.currentValue, 20);
     });
 
     test('missing product in map falls back to receipt buy price snapshot', () {
@@ -154,6 +305,25 @@ void main() {
         loanedLogs: [],
         productMap: {},
       );
+      expect(result, isEmpty);
+    });
+
+    test('loaner with non-positive balance is skipped', () {
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 0);
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 999, buyPrice: 10, sellPrice: 20, count: 5),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [log],
+        productMap: {},
+      );
+
       expect(result, isEmpty);
     });
 

--- a/test/unit/loaner_comparison_test.dart
+++ b/test/unit/loaner_comparison_test.dart
@@ -49,6 +49,7 @@ EmbeddedProduct _makeEmbedded({
   required double buyPrice,
   required double sellPrice,
   required int count,
+  bool hot = false,
 }) {
   final ep = EmbeddedProduct();
   ep.productId = productId;
@@ -56,7 +57,7 @@ EmbeddedProduct _makeEmbedded({
   ep.buyPrice = buyPrice;
   ep.sellPrice = sellPrice;
   ep.count = count;
-  ep.hot = false;
+  ep.hot = hot;
   return ep;
 }
 
@@ -366,6 +367,34 @@ void main() {
 
       expect(result.first.loanedAmount, 200);
       expect(result.first.currentValue, 50);
+    });
+
+    test('skips hot products from the current value only', () {
+      final product = _makeProduct(id: 1, buyPrice: 10);
+      final loaner = _makeLoaner(id: 5, name: 'Ahmed', balance: 260);
+      final log = _makeLoanedLog(
+        loanerId: 5,
+        date: DateTime(2026, 5, 10),
+        products: [
+          _makeEmbedded(productId: 1, buyPrice: 10, sellPrice: 30, count: 2),
+          _makeEmbedded(
+            productId: 2,
+            buyPrice: 100,
+            sellPrice: 200,
+            count: 1,
+            hot: true,
+          ),
+        ],
+      );
+
+      final result = computeLoanerComparison(
+        loaners: [loaner],
+        loanedLogs: [log],
+        productMap: {1: product, 2: _makeProduct(id: 2, buyPrice: 100)},
+      );
+
+      expect(result.first.loanedAmount, (30 * 2) + (200 * 1));
+      expect(result.first.currentValue, 20);
     });
 
     test('loaner with no loaned logs is skipped', () {


### PR DESCRIPTION
 ## 2.4.18
- Inventory page now refreshes deterministically after editing a product: the DB write is awaited before listeners are notified, removing the intermittent stale-tile race.
- New products added from the inventory page now appear in the grid immediately (insert also notifies inventory listeners after persisting).
- Loaner debt window now counts hot products at sell price (`logLoanedValue`), so the window/current value step correctly.
- Replaced the loaner comparison chart with a diverging profit/loss chart (green = loaner still owes tracked value, red = loaner overpaid).
- Fixed null-offer crash when editing a receipt that contains hot products.
- Fixed buy/sell mismatch: editing or canceling a receipt now subtracts hot products at sell price, matching checkout.
- Sell page now refreshes immediately after a receipt edit restores products to the cart.