### PR TITLE
Hot v2.4.20

### DIFF
--- a/lib/core/db/db.dart
+++ b/lib/core/db/db.dart
@@ -247,7 +247,7 @@ class DB {
     bool expense = false,
     int? expenseId,
   }) async {
-    try {
+    return AppLogger.trace<bool>('checkout', 'checkout', () async {
       if (discount < 0) {
         throw Exception('Discount must be non-negative');
       }
@@ -474,10 +474,7 @@ class DB {
         }
       }
       return success;
-    } catch (e, st) {
-      await AppLogger.captureException(e, stackTrace: st, area: 'checkout');
-      rethrow;
-    }
+    }, data: {'productCount': products.length, 'total': total});
   }
 
   Stream<List<Expense>> getExpenses({required bool fixed}) {

--- a/lib/core/observability.dart
+++ b/lib/core/observability.dart
@@ -52,6 +52,25 @@ class AppLogger {
     options.attachStacktrace = true;
     options.maxBreadcrumbs = 100;
     options.tracesSampleRate = 1.0;
+
+    // Filter out known validation errors that are not bugs.
+    options.beforeSend = (event, hint) {
+      final msg = event.exceptions?.firstOrNull?.value ?? '';
+      if (_isValidationError(msg)) return null;
+      return event;
+    };
+  }
+
+  /// Known validation messages that should not be reported to Sentry.
+  static final _validationErrors = RegExp(
+    r'Discount must be non-negative|'
+    r'Discount cannot exceed checkout total|'
+    r'Insufficient stock',
+    caseSensitive: false,
+  );
+
+  static bool _isValidationError(String message) {
+    return _validationErrors.hasMatch(message);
   }
 
   static Future<void> _runGuarded(Future<void> Function() appRunner) async {
@@ -175,6 +194,105 @@ class AppLogger {
     ));
   }
 
+  // ── User context ──────────────────────────────────────────────────────
+
+  /// Associates the current Sentry session with a user.
+  /// Call after successful login; PII is stripped by [sanitizeText].
+  static void setUser(String? userId, {String? email, String? username}) {
+    if (!ObservabilityConfig.crashReportingEnabled || !_sentryStarted) return;
+    Sentry.configureScope((scope) {
+      scope.setUser(SentryUser(
+        id: userId,
+        email: email != null ? sanitizeText(email) : null,
+        username: username != null ? sanitizeText(username) : null,
+      ));
+    });
+  }
+
+  /// Clears the user from the Sentry scope. Call on sign-out.
+  static void clearUser() {
+    if (!ObservabilityConfig.crashReportingEnabled || !_sentryStarted) return;
+    Sentry.configureScope((scope) {
+      scope.setUser(null);
+    });
+  }
+
+  // ── Tags ──────────────────────────────────────────────────────────────
+
+  /// Sets a tag on the current Sentry scope. Tags are indexed and
+  /// searchable in the Sentry UI (e.g. `area`, `feature`).
+  static void setTag(String key, String value) {
+    if (!ObservabilityConfig.crashReportingEnabled || !_sentryStarted) return;
+    Sentry.configureScope((scope) {
+      scope.setTag(key, value);
+    });
+  }
+
+  // ── Performance monitoring ────────────────────────────────────────────
+
+  /// Starts a Sentry transaction for performance monitoring.
+  /// Returns the [SentrySpan] which must be passed to [finishTransaction].
+  ///
+  /// Example:
+  /// ```dart
+  /// final txn = AppLogger.startTransaction('checkout', 'checkout');
+  /// try {
+  ///   await _doCheckout();
+  ///   txn.finish(status: SpanStatus.ok());
+  /// } catch (e) {
+  ///   txn.finish(status: SpanStatus.internalError());
+  ///   rethrow;
+  /// }
+  /// ```
+  static Future<ISentrySpan> startTransaction(
+    String name,
+    String operation, {
+    Map<String, Object?>? data,
+  }) async {
+    if (!ObservabilityConfig.crashReportingEnabled || !_sentryStarted) {
+      return _NoopSpan();
+    }
+    final transaction = Sentry.startTransaction(
+      name,
+      operation,
+      bindToScope: true,
+    );
+    if (data != null) {
+      for (final entry in sanitizeMap(data).entries) {
+        transaction.setData(entry.key, entry.value);
+      }
+    }
+    return transaction;
+  }
+
+  /// Convenience wrapper: runs [fn] inside a Sentry transaction,
+  /// automatically finishing with [SpanStatus.ok] on success or
+  /// [SpanStatus.internalError] on exception.
+  ///
+  /// Example:
+  /// ```dart
+  /// await AppLogger.trace('checkout', 'checkout', () async {
+  ///   await _performCheckout();
+  /// }, data: {'productCount': items.length});
+  /// ```
+  static Future<T> trace<T>(
+    String name,
+    String operation,
+    Future<T> Function() fn, {
+    Map<String, Object?>? data,
+  }) async {
+    final span = await startTransaction(name, operation, data: data);
+    try {
+      final result = await fn();
+      span.finish(status: SpanStatus.ok());
+      return result;
+    } catch (e) {
+      span.throwable = e;
+      span.finish(status: SpanStatus.internalError());
+      rethrow;
+    }
+  }
+
   @visibleForTesting
   static Map<String, dynamic> sanitizeMap(Map<String, Object?>? data) {
     if (data == null || data.isEmpty) return {};
@@ -248,4 +366,14 @@ class UserSafeMessages {
   static const syncFailed =
       'فشلت المزامنة. تحقق من الشبكة وعنوان المشاركة ثم حاول مرة أخرى.';
   static const pdfFailed = 'تعذر إنشاء ملف PDF. حاول مرة أخرى.';
+}
+
+/// A no-op span returned when Sentry is not enabled, so callers
+/// don't need null-checks.
+class _NoopSpan implements ISentrySpan {
+  @override
+  Future<void> finish({SpanStatus? status, DateTime? endTimestamp, dynamic hint}) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {}
 }

--- a/lib/models/PendingCart.dart
+++ b/lib/models/PendingCart.dart
@@ -63,7 +63,7 @@ class PendingCart {
       p.priceHistory = history.map((e) {
         final em = e as Map<String, dynamic>;
         return Emap()
-          ..date = em['date']
+          ..date = em['date'] != null ? DateTime.parse(em['date'] as String) : null
           ..buyPrice = em['buyPrice']
           ..sellPrice = em['sellPrice'];
       }).toList();

--- a/lib/models/Product.dart
+++ b/lib/models/Product.dart
@@ -128,7 +128,7 @@ class Product {
     offerPrice = double.parse(map['offerPrice'].toString());
     priceHistory = (map['priceHistory'] as List<Map<String, dynamic>>)
         .map((e) => Emap()
-          ..date = e['date']
+          ..date = e['date'] != null ? DateTime.parse(e['date'] as String) : null
           ..buyPrice = e['buyPrice']
           ..sellPrice = e['sellPrice'])
         .toList();

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -37,6 +37,8 @@ class AuthAPI extends ChangeNotifier with WidgetsBindingObserver {
   User? _currentUser;
   AuthStatus _status = AuthStatus.uninitialized;
   bool _isOffline = false;
+  Timer? _revalidationTimer;
+  bool _isPinging = false;
   Storage? storage;
 
   User? get currentUser => _currentUser;
@@ -97,35 +99,63 @@ class AuthAPI extends ChangeNotifier with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed &&
+    if (state == AppLifecycleState.paused) {
+      _revalidationTimer?.cancel();
+      _revalidationTimer = null;
+    } else if (state == AppLifecycleState.resumed &&
         _status == AuthStatus.authenticated) {
-      unawaited(_pingServer(area: 'auth.lifecycle'));
+      _startRevalidationTimer();
     }
   }
 
+  @override
+  void dispose() {
+    _revalidationTimer?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
   Future<void> _pingServer({required String area}) async {
+    if (_isPinging) return;
+    _isPinging = true;
     try {
       final user = await account.get();
       _isOffline = false;
       _currentUser = user;
-      await _saveSession(user);
-      notifyListeners();
+      await _updateLastPingTime();
       AppLogger.debug('Heartbeat ok', data: {'area': area});
     } catch (_) {
-      // Expected while offline; keep the project quiet instead of spamming.
+      _isOffline = true;
       AppLogger.debug('Heartbeat ping failed (offline?)',
           data: {'area': area});
+    } finally {
+      _isPinging = false;
+      _startRevalidationTimer();
+    }
+  }
+
+  Future<void> _updateLastPingTime() async {
+    try {
+      await _secureStorage.write(
+        key: KEY_SESSION_TIME,
+        value: DateTime.now().millisecondsSinceEpoch.toString(),
+      );
+    } catch (e) {
+      AppLogger.debug('Failed to update session time',
+          data: {'area': 'auth.ping_time', 'error': e.toString()});
     }
   }
 
   // keep-alive so Appwrite does not flag the project as inactive
   void _startRevalidationTimer() {
-    Future.delayed(
-        _isOffline ? revalidationInterval : heartbeatInterval, () async {
-      if (_status != AuthStatus.authenticated) return;
-      unawaited(_pingServer(area: 'auth.heartbeat'));
-      _startRevalidationTimer();
-    });
+    _revalidationTimer?.cancel();
+    _revalidationTimer = Timer(
+      _isOffline ? revalidationInterval : heartbeatInterval,
+      () async {
+        if (_status != AuthStatus.authenticated) return;
+        await _pingServer(area: 'auth.heartbeat');
+      },
+    );
   }
 
   Future<bool> checkOfflineSession() async {
@@ -212,6 +242,7 @@ class AuthAPI extends ChangeNotifier with WidgetsBindingObserver {
       _isOffline = false;
       _currentUser = user;
       await _saveSession(user);
+      AppLogger.setUser(user.$id, email: user.email, username: user.name);
     } catch (_) {
       if (await checkOfflineSession()) {
         AppLogger.info('Using offline auth session', data: {'area': 'auth'});
@@ -276,6 +307,8 @@ class AuthAPI extends ChangeNotifier with WidgetsBindingObserver {
       _status = AuthStatus.authenticated;
       _isOffline = false;
       await _saveSession(_currentUser!);
+      AppLogger.setUser(_currentUser!.$id,
+          email: _currentUser!.email, username: _currentUser!.name);
       return session;
     } finally {
       notifyListeners();
@@ -294,6 +327,8 @@ class AuthAPI extends ChangeNotifier with WidgetsBindingObserver {
       _status = AuthStatus.authenticated;
       _isOffline = false;
       await _saveSession(_currentUser!);
+      AppLogger.setUser(_currentUser!.$id,
+          email: _currentUser!.email, username: _currentUser!.name);
       notifyListeners();
     } catch (e, st) {
       await AppLogger.captureException(e, stackTrace: st, area: 'auth.oauth');
@@ -369,6 +404,9 @@ class AuthAPI extends ChangeNotifier with WidgetsBindingObserver {
 ''';
 
   signOut() async {
+    _revalidationTimer?.cancel();
+    _revalidationTimer = null;
+    AppLogger.clearUser();
     try {
       await account.deleteSession(sessionId: 'current');
     } finally {
@@ -397,79 +435,84 @@ class AuthAPI extends ChangeNotifier with WidgetsBindingObserver {
   static String backupHash(List<int> bytes) =>
       sha256.convert(bytes).toString();
   Future<void> uploadBackup() async {
-    try {
-      final dir = await getApplicationDocumentsDirectory();
-      final file = IO.File('${dir.path}/${DB.liveDatabaseFileName}');
-      if (!await file.exists()) return;
-
-      final fileId = 'backup_${_currentUser!.$id}.isar.gz';
-      final fileBytes = await file.readAsBytes();
-
-      // Skip re-uploading when the local DB has not changed since last time.
-      final hash = sha256.convert(fileBytes).toString();
-      final lastHash = await _secureStorage.read(key: KEY_LAST_BACKUP_HASH);
-      if (lastHash == hash) {
-        AppLogger.debug('Backup unchanged, skipping upload',
-            data: {'area': 'backup.upload'});
-        return;
-      }
-
-      final compressed = IO.gzip.encode(fileBytes);
-
+    return AppLogger.trace<void>('backup.upload', 'backup', () async {
       try {
-        await storage!.getFile(
+        final dir = await getApplicationDocumentsDirectory();
+        final file = IO.File('${dir.path}/${DB.liveDatabaseFileName}');
+        if (!await file.exists()) return;
+
+        final fileId = 'backup_${_currentUser!.$id}.isar.gz';
+        final fileBytes = await file.readAsBytes();
+
+        // Skip re-uploading when the local DB has not changed since last time.
+        final hash = sha256.convert(fileBytes).toString();
+        final lastHash = await _secureStorage.read(key: KEY_LAST_BACKUP_HASH);
+        if (lastHash == hash) {
+          AppLogger.debug('Backup unchanged, skipping upload',
+              data: {'area': 'backup.upload'});
+          return;
+        }
+
+        final compressed = IO.gzip.encode(fileBytes);
+
+        try {
+          await storage!.getFile(
+            bucketId: AppwriteConfig.bucketId,
+            fileId: fileId,
+          );
+          await storage!.deleteFile(
+            bucketId: AppwriteConfig.bucketId,
+            fileId: fileId,
+          );
+        } catch (e, st) {
+          await AppLogger.captureException(e,
+              stackTrace: st, area: 'backup.upload.delete_existing');
+        }
+
+        await storage!.createFile(
           bucketId: AppwriteConfig.bucketId,
           fileId: fileId,
+          file: InputFile.fromBytes(
+            bytes: compressed,
+            filename: 'backup_${_currentUser!.$id}.isar.gz',
+          ),
         );
-        await storage!.deleteFile(
-          bucketId: AppwriteConfig.bucketId,
-          fileId: fileId,
-        );
+        await _secureStorage.write(key: KEY_LAST_BACKUP_HASH, value: hash);
+        AppLogger.info('Backup uploaded',
+            data: {'area': 'backup.upload', 'sizeBytes': fileBytes.length});
       } catch (e, st) {
         await AppLogger.captureException(e,
-            stackTrace: st, area: 'backup.upload.delete_existing');
+            stackTrace: st, area: 'backup.upload');
+        rethrow;
       }
-
-      await storage!.createFile(
-        bucketId: AppwriteConfig.bucketId,
-        fileId: fileId,
-        file: InputFile.fromBytes(
-          bytes: compressed,
-          filename: 'backup_${_currentUser!.$id}.isar.gz',
-        ),
-      );
-      await _secureStorage.write(key: KEY_LAST_BACKUP_HASH, value: hash);
-      AppLogger.info('Backup uploaded',
-          data: {'area': 'backup.upload', 'sizeBytes': fileBytes.length});
-    } catch (e, st) {
-      await AppLogger.captureException(e,
-          stackTrace: st, area: 'backup.upload');
-      rethrow;
-    }
+    }, data: {'userId': _currentUser?.$id});
   }
 
   Future<void> downloadBackup() async {
-    try {
-      final dir = await getApplicationDocumentsDirectory();
-      final filePath = '${dir.path}/${DB.liveDatabaseFileName}';
-      final fileId = 'backup_${_currentUser!.$id}.isar.gz';
+    return AppLogger.trace<void>('backup.download', 'backup', () async {
+      try {
+        final dir = await getApplicationDocumentsDirectory();
+        final filePath = '${dir.path}/${DB.liveDatabaseFileName}';
+        final fileId = 'backup_${_currentUser!.$id}.isar.gz';
 
-      final response = await storage!.getFileDownload(
-        bucketId: AppwriteConfig.bucketId,
-        fileId: fileId,
-      );
+        final response = await storage!.getFileDownload(
+          bucketId: AppwriteConfig.bucketId,
+          fileId: fileId,
+        );
 
-      final decompressed = IO.gzip.decode(response);
-      final file = IO.File(filePath);
-      await file.writeAsBytes(decompressed);
-      // Invalidate the skip marker so the next upload is not skipped.
-      await _secureStorage.delete(key: KEY_LAST_BACKUP_HASH);
-      AppLogger.info('Backup downloaded', data: {'area': 'backup.download'});
-    } catch (e, st) {
-      await AppLogger.captureException(e,
-          stackTrace: st, area: 'backup.download');
-      rethrow;
-    }
+        final decompressed = IO.gzip.decode(response);
+        final file = IO.File(filePath);
+        await file.writeAsBytes(decompressed);
+        // Invalidate the skip marker so the next upload is not skipped.
+        await _secureStorage.delete(key: KEY_LAST_BACKUP_HASH);
+        AppLogger.info('Backup downloaded',
+            data: {'area': 'backup.download'});
+      } catch (e, st) {
+        await AppLogger.captureException(e,
+            stackTrace: st, area: 'backup.download');
+        rethrow;
+      }
+    }, data: {'userId': _currentUser?.$id});
   }
 
   void uploadPaymentReceipt({required IO.File receipt}) {}

--- a/lib/providers/share_provider.dart
+++ b/lib/providers/share_provider.dart
@@ -34,13 +34,14 @@ class ShareProvider extends ChangeNotifier with LanSyncState {
   }
 
   Future<void> runServer() async {
-    await _syncServer?.close(force: true);
-    _syncServer = null;
-    setSyncState(
-      SyncStatus.connecting,
-      message: 'جار تجهيز خادم المزامنة المحلية...',
-      progress: 0,
-    );
+    return AppLogger.trace<void>('sync.server', 'sync', () async {
+      await _syncServer?.close(force: true);
+      _syncServer = null;
+      setSyncState(
+        SyncStatus.connecting,
+        message: 'جار تجهيز خادم المزامنة المحلية...',
+        progress: 0,
+      );
 
     try {
       final packageInfo = await PackageInfo.fromPlatform();
@@ -95,18 +96,20 @@ class ShareProvider extends ChangeNotifier with LanSyncState {
       _syncServer = null;
       notifyListeners();
     }
+    });
   }
 
   Future<void> syncFromServer(String input) async {
-    final endpoint = LanSyncEndpoint.tryParse(input);
-    if (endpoint == null) {
-      setSyncState(
-        SyncStatus.error,
-        message: 'عنوان المشاركة غير صحيح',
-        error: 'استخدم IP أو IP:PORT من جهاز الإرسال.',
-      );
-      return;
-    }
+    return AppLogger.trace<void>('sync.client', 'sync', () async {
+      final endpoint = LanSyncEndpoint.tryParse(input);
+      if (endpoint == null) {
+        setSyncState(
+          SyncStatus.error,
+          message: 'عنوان المشاركة غير صحيح',
+          error: 'استخدم IP أو IP:PORT من جهاز الإرسال.',
+        );
+        return;
+      }
 
     final dir = await getApplicationDocumentsDirectory();
     final downloadPath = _downloadedBackupPath(dir.path);
@@ -205,6 +208,7 @@ class ShareProvider extends ChangeNotifier with LanSyncState {
       _syncCancelToken = null;
       notifyListeners();
     }
+    });
   }
 
   void cancelSync() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,7 @@ description: a retail shop management app.
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-
-version: 2.4.19+1
+version: 2.4.20+1
 
 environment:
   sdk: ">=3.0.5 <4.0.0"


### PR DESCRIPTION
fix: DateTime parse crash, heartbeat refactor, and Sentry instrumentation

- Fix String-to-DateTime? crash in PendingCart._productFromMap and
  Product.fromJson when deserializing priceHistory entries
- Refactor heartbeat: cancellable Timer, _isPinging overlap guard,
  _isOffline set on failure, cancel on pause/dispose/signOut,
  only write last_login_time on heartbeat instead of full session
- Add Sentry user context (setUser/clearUser) in auth flow
- Add AppLogger.trace() for performance monitoring on checkout,
  backup upload/download, and LAN sync
- Add beforeSend callback to filter known validation errors